### PR TITLE
Arquivo html para leitura com pandas

### DIFF
--- a/AFI's 100 Years...100 Movies - Wikipedia.htm
+++ b/AFI's 100 Years...100 Movies - Wikipedia.htm
@@ -1,0 +1,1819 @@
+<!DOCTYPE html>
+<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-enabled vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-available" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<title>AFI's 100 Years...100 Movies - Wikipedia</title>
+<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-enabled vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-available";var cookie=document.cookie.match(/(?:^|; )enwikimwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\w+$|[^\w-]+/g,'')+'-clientpref-\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":[
+"",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"cefc7372-56d2-45c8-a61f-a94b26f7db48","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"AFI's_100_Years...100_Movies","wgTitle":"AFI's 100 Years...100 Movies","wgCurRevisionId":1217354641,"wgRevisionId":1217354641,"wgArticleId":718307,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Articles with short description","Short description is different from Wikidata","AFI 100 Years... series"],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"AFI's_100_Years...100_Movies","wgRelevantArticleId":718307,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgNoticeProject":"wikipedia",
+"wgCiteReferencePreviewsActive":false,"wgFlaggedRevsParams":{"tags":{"status":{"levels":1}}},"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgPopupsFlags":6,"wgVisualEditor":{"pageLanguageCode":"en","pageLanguageDir":"ltr","pageVariantFallbacks":"en"},"wgMFDisplayWikibaseDescriptions":{"search":true,"watchlist":true,"tagline":false,"nearby":true},"wgWMESchemaEditAttemptStepOversample":false,"wgWMEPageLength":30000,"wgULSCurrentAutonym":"English","wgCentralAuthMobileDomain":false,"wgEditSubmitButtonLabelPublish":true,"wgULSPosition":"interlanguage","wgULSisCompactLinksEnabled":false,"wgVector2022LanguageInHeader":true,"wgULSisLanguageSelectorEmpty":false,"wgWikibaseItemId":"Q719345","wgCheckUserClientHintsHeadersJsApi":["architecture","bitness","brands","fullVersionList","mobile","model","platform","platformVersion"],"GEHomepageSuggestedEditsEnableTopics":true,"wgGETopicsMatchModeEnabled":false,"wgGEStructuredTaskRejectionReasonTextInputEnabled":false,
+"wgGELevelingUpEnabledForUser":false};RLSTATE={"ext.globalCssJs.user.styles":"ready","site.styles":"ready","user.styles":"ready","ext.globalCssJs.user":"ready","user":"ready","user.options":"loading","ext.cite.styles":"ready","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","jquery.tablesorter.styles":"ready","ext.wikimediamessages.styles":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.uls.interlanguage":"ready","wikibase.client.init":"ready","ext.wikimediaBadges":"ready"};RLPAGEMODULES=["ext.cite.ux-enhancements","site","mediawiki.page.ready","jquery.tablesorter","mediawiki.toc","skins.vector.js","ext.centralNotice.geoIP","ext.centralNotice.startUp","ext.gadget.ReferenceTooltips","ext.gadget.switcher","ext.urlShortener.toolbar","ext.centralauth.centralautologin","ext.popups","ext.visualEditor.desktopArticleTarget.init","ext.visualEditor.targetLoader","ext.echo.centralauth","ext.eventLogging",
+"ext.wikimediaEvents","ext.navigationTiming","ext.uls.interface","ext.cx.eventlogging.campaigns","ext.cx.uls.quick.actions","wikibase.client.vector-2022","ext.checkUser.clientHints","ext.quicksurveys.init","ext.growthExperiments.SuggestedEditSession"];</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
+}];});});</script>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.cite.styles%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediaBadges%7Cext.wikimediamessages.styles%7Cjquery.tablesorter.styles%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles%7Cwikibase.client.init&amp;only=styles&amp;skin=vector-2022">
+<script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>
+<meta name="ResourceLoaderDynamicStyles" content="">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022">
+<meta name="generator" content="MediaWiki 1.43.0-wmf.9">
+<meta name="referrer" content="origin">
+<meta name="referrer" content="origin-when-cross-origin">
+<meta name="robots" content="max-image-preview:standard">
+<meta name="format-detection" content="telephone=no">
+<meta name="viewport" content="width=1120">
+<meta property="og:title" content="AFI&#039;s 100 Years...100 Movies - Wikipedia">
+<meta property="og:type" content="website">
+<link rel="alternate" media="only screen and (max-width: 640px)" href="//en.m.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies">
+<link rel="alternate" type="application/x-wiki" title="Edit this page" href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit">
+<link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png">
+<link rel="icon" href="/static/favicon/wikipedia.ico">
+<link rel="search" type="application/opensearchdescription+xml" href="/w/rest.php/v1/search" title="Wikipedia (en)">
+<link rel="EditURI" type="application/rsd+xml" href="//en.wikipedia.org/w/api.php?action=rsd">
+<link rel="canonical" href="https://en.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies">
+<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.en">
+<link rel="alternate" type="application/atom+xml" title="Wikipedia Atom feed" href="/w/index.php?title=Special:RecentChanges&amp;feed=atom">
+<link rel="dns-prefetch" href="//meta.wikimedia.org" />
+<link rel="dns-prefetch" href="//login.wikimedia.org">
+</head>
+<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-AFI_s_100_Years_100_Movies rootpage-AFI_s_100_Years_100_Movies skin-vector-2022 action-view"><a class="mw-jump-link" href="#bodyContent">Jump to content</a>
+<div class="vector-header-container">
+	<header class="vector-header mw-header">
+		<div class="vector-header-start">
+			<nav class="vector-main-menu-landmark" aria-label="Site">
+				
+<div id="vector-main-menu-dropdown" class="vector-dropdown vector-main-menu-dropdown vector-button-flush-left vector-button-flush-right"  >
+	<input type="checkbox" id="vector-main-menu-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-main-menu-dropdown" class="vector-dropdown-checkbox "  aria-label="Main menu"  >
+	<label id="vector-main-menu-dropdown-label" for="vector-main-menu-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-menu mw-ui-icon-wikimedia-menu"></span>
+
+<span class="vector-dropdown-label-text">Main menu</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+				<div id="vector-main-menu-unpinned-container" class="vector-unpinned-container">
+		
+<div id="vector-main-menu" class="vector-main-menu vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-main-menu-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="main-menu-pinned"
+	data-pinnable-element-id="vector-main-menu"
+	data-pinned-container-id="vector-main-menu-pinned-container"
+	data-unpinned-container-id="vector-main-menu-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Main menu</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-main-menu.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-main-menu.unpin">hide</button>
+</div>
+
+	
+<div id="p-navigation" class="vector-menu mw-portlet mw-portlet-navigation"  >
+	<div class="vector-menu-heading">
+		Navigation
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-mainpage-description" class="mw-list-item"><a href="/wiki/Main_Page" title="Visit the main page [z]" accesskey="z"><span>Main page</span></a></li><li id="n-contents" class="mw-list-item"><a href="/wiki/Wikipedia:Contents" title="Guides to browsing Wikipedia"><span>Contents</span></a></li><li id="n-currentevents" class="mw-list-item"><a href="/wiki/Portal:Current_events" title="Articles related to current events"><span>Current events</span></a></li><li id="n-randompage" class="mw-list-item"><a href="/wiki/Special:Random" title="Visit a randomly selected article [x]" accesskey="x"><span>Random article</span></a></li><li id="n-aboutsite" class="mw-list-item"><a href="/wiki/Wikipedia:About" title="Learn about Wikipedia and how it works"><span>About Wikipedia</span></a></li><li id="n-contactpage" class="mw-list-item"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us" title="How to contact Wikipedia"><span>Contact us</span></a></li><li id="n-sitesupport" class="mw-list-item"><a href="https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wikipedia.org&amp;uselang=en" title="Support us by donating to the Wikimedia Foundation"><span>Donate</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	
+<div id="p-interaction" class="vector-menu mw-portlet mw-portlet-interaction"  >
+	<div class="vector-menu-heading">
+		Contribute
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-help" class="mw-list-item"><a href="/wiki/Help:Contents" title="Guidance on how to use and edit Wikipedia"><span>Help</span></a></li><li id="n-introduction" class="mw-list-item"><a href="/wiki/Help:Introduction" title="Learn how to edit Wikipedia"><span>Learn to edit</span></a></li><li id="n-portal" class="mw-list-item"><a href="/wiki/Wikipedia:Community_portal" title="The hub for editors"><span>Community portal</span></a></li><li id="n-recentchanges" class="mw-list-item"><a href="/wiki/Special:RecentChanges" title="A list of recent changes to Wikipedia [r]" accesskey="r"><span>Recent changes</span></a></li><li id="n-upload" class="mw-list-item"><a href="/wiki/Wikipedia:File_upload_wizard" title="Add images or other media for use on Wikipedia"><span>Upload file</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+				</div>
+
+	</div>
+</div>
+
+		</nav>
+			
+<a href="/wiki/Main_Page" class="mw-logo">
+	<img class="mw-logo-icon" src="/static/images/icons/wikipedia.png" alt="" aria-hidden="true" height="50" width="50">
+	<span class="mw-logo-container skin-invert">
+		<img class="mw-logo-wordmark" alt="Wikipedia" src="/static/images/mobile/copyright/wikipedia-wordmark-en.svg" style="width: 7.5em; height: 1.125em;">
+		<img class="mw-logo-tagline" alt="The Free Encyclopedia" src="/static/images/mobile/copyright/wikipedia-tagline-en.svg" width="117" height="13" style="width: 7.3125em; height: 0.8125em;">
+	</span>
+</a>
+
+		</div>
+		<div class="vector-header-end">
+			
+<div id="p-search" role="search" class="vector-search-box-vue  vector-search-box-collapses vector-search-box-show-thumbnail vector-search-box-auto-expand-width vector-search-box">
+	<a href="/wiki/Special:Search" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only search-toggle" title="Search Wikipedia [f]" accesskey="f"><span class="vector-icon mw-ui-icon-search mw-ui-icon-wikimedia-search"></span>
+
+<span>Search</span>
+	</a>
+	<div class="vector-typeahead-search-container">
+		<div class="cdx-typeahead-search cdx-typeahead-search--show-thumbnail cdx-typeahead-search--auto-expand-width">
+			<form action="/w/index.php" id="searchform" class="cdx-search-input cdx-search-input--has-end-button">
+				<div id="simpleSearch" class="cdx-search-input__input-wrapper"  data-search-loc="header-moved">
+					<div class="cdx-text-input cdx-text-input--has-start-icon">
+						<input
+							class="cdx-text-input__input"
+							 type="search" name="search" placeholder="Search Wikipedia" aria-label="Search Wikipedia" autocapitalize="sentences" title="Search Wikipedia [f]" accesskey="f" id="searchInput"
+							>
+						<span class="cdx-text-input__icon cdx-text-input__start-icon"></span>
+					</div>
+					<input type="hidden" name="title" value="Special:Search">
+				</div>
+				<button class="cdx-button cdx-search-input__end-button">Search</button>
+			</form>
+		</div>
+	</div>
+</div>
+
+			<nav class="vector-user-links vector-user-links-wide" aria-label="Personal tools">
+	<div class="vector-user-links-main">
+	
+<div id="p-vector-user-menu-preferences" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-userpage" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	<nav class="vector-appearance-landmark" aria-label="Appearance">
+		
+<div id="vector-appearance-dropdown" class="vector-dropdown "  >
+	<input type="checkbox" id="vector-appearance-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-appearance-dropdown" class="vector-dropdown-checkbox "  aria-label="Appearance"  >
+	<label id="vector-appearance-dropdown-label" for="vector-appearance-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-appearance mw-ui-icon-wikimedia-appearance"></span>
+
+<span class="vector-dropdown-label-text">Appearance</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+			<div id="vector-appearance-unpinned-container" class="vector-unpinned-container">
+				
+			</div>
+		
+	</div>
+</div>
+
+	</nav>
+	
+<div id="p-vector-user-menu-notifications" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-overflow" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-createaccount-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/w/index.php?title=Special:CreateAccount&amp;returnto=AFI%27s+100+Years...100+Movies" title="You are encouraged to create an account and log in; however, it is not mandatory" class=""><span>Create account</span></a>
+</li>
+<li id="pt-login-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/w/index.php?title=Special:UserLogin&amp;returnto=AFI%27s+100+Years...100+Movies" title="You&#039;re encouraged to log in; however, it&#039;s not mandatory. [o]" accesskey="o" class=""><span>Log in</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	</div>
+	
+<div id="vector-user-links-dropdown" class="vector-dropdown vector-user-menu vector-button-flush-right vector-user-menu-logged-out"  title="Log in and more options" >
+	<input type="checkbox" id="vector-user-links-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-user-links-dropdown" class="vector-dropdown-checkbox "  aria-label="Personal tools"  >
+	<label id="vector-user-links-dropdown-label" for="vector-user-links-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-ellipsis mw-ui-icon-wikimedia-ellipsis"></span>
+
+<span class="vector-dropdown-label-text">Personal tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+		
+<div id="p-personal" class="vector-menu mw-portlet mw-portlet-personal user-links-collapsible-item"  title="User menu" >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-createaccount" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Special:CreateAccount&amp;returnto=AFI%27s+100+Years...100+Movies" title="You are encouraged to create an account and log in; however, it is not mandatory"><span class="vector-icon mw-ui-icon-userAdd mw-ui-icon-wikimedia-userAdd"></span> <span>Create account</span></a></li><li id="pt-login" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=AFI%27s+100+Years...100+Movies" title="You&#039;re encouraged to log in; however, it&#039;s not mandatory. [o]" accesskey="o"><span class="vector-icon mw-ui-icon-logIn mw-ui-icon-wikimedia-logIn"></span> <span>Log in</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-user-menu-anon-editor" class="vector-menu mw-portlet mw-portlet-user-menu-anon-editor"  >
+	<div class="vector-menu-heading">
+		Pages for logged out editors <a href="/wiki/Help:Introduction" aria-label="Learn more about editing"><span>learn more</span></a>
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-anoncontribs" class="mw-list-item"><a href="/wiki/Special:MyContributions" title="A list of edits made from this IP address [y]" accesskey="y"><span>Contributions</span></a></li><li id="pt-anontalk" class="mw-list-item"><a href="/wiki/Special:MyTalk" title="Discussion about edits from this IP address [n]" accesskey="n"><span>Talk</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	</div>
+</div>
+
+</nav>
+
+		</div>
+	</header>
+</div>
+<div class="mw-page-container">
+	<div class="mw-page-container-inner">
+		<div class="vector-sitenotice-container">
+			<div id="siteNotice" class="notheme"><!-- CentralNotice --></div>
+		</div>
+		<div class="vector-column-start">
+			<div class="vector-main-menu-container">
+		<div id="mw-navigation">
+			<nav id="mw-panel" class="vector-main-menu-landmark" aria-label="Site">
+				<div id="vector-main-menu-pinned-container" class="vector-pinned-container">
+				
+				</div>
+		</nav>
+		</div>
+	</div>
+	<div class="vector-sticky-pinned-container">
+				<nav id="mw-panel-toc" aria-label="Contents" data-event-name="ui.sidebar-toc" class="mw-table-of-contents-container vector-toc-landmark">
+					<div id="vector-toc-pinned-container" class="vector-pinned-container">
+					<div id="vector-toc" class="vector-toc vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-toc-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="toc-pinned"
+	data-pinnable-element-id="vector-toc"
+	
+	
+>
+	<h2 class="vector-pinnable-header-label">Contents</h2>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-toc.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-toc.unpin">hide</button>
+</div>
+
+
+	<ul class="vector-toc-contents" id="mw-panel-toc-list">
+		<li id="toc-mw-content-text"
+			class="vector-toc-list-item vector-toc-level-1">
+			<a href="#" class="vector-toc-link">
+				<div class="vector-toc-text">(Top)</div>
+			</a>
+		</li>
+		<li id="toc-Criteria"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Criteria">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">1</span>
+				<span>Criteria</span>
+			</div>
+		</a>
+		
+		<ul id="toc-Criteria-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-List"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#List">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">2</span>
+				<span>List</span>
+			</div>
+		</a>
+		
+			<button aria-controls="toc-List-sublist" class="cdx-button cdx-button--weight-quiet cdx-button--icon-only vector-toc-toggle">
+				<span class="vector-icon mw-ui-icon-wikimedia-expand"></span>
+				<span>Toggle List subsection</span>
+			</button>
+		
+		<ul id="toc-List-sublist" class="vector-toc-list">
+			<li id="toc-2007_changes"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#2007_changes">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">2.1</span>
+					<span>2007 changes</span>
+				</div>
+			</a>
+			
+			<ul id="toc-2007_changes-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+	</ul>
+	</li>
+	<li id="toc-Broadcast_history"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Broadcast_history">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">3</span>
+				<span>Broadcast history</span>
+			</div>
+		</a>
+		
+			<button aria-controls="toc-Broadcast_history-sublist" class="cdx-button cdx-button--weight-quiet cdx-button--icon-only vector-toc-toggle">
+				<span class="vector-icon mw-ui-icon-wikimedia-expand"></span>
+				<span>Toggle Broadcast history subsection</span>
+			</button>
+		
+		<ul id="toc-Broadcast_history-sublist" class="vector-toc-list">
+			<li id="toc-Presentation_broadcast_on_CBS"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Presentation_broadcast_on_CBS">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">3.1</span>
+					<span>Presentation broadcast on CBS</span>
+				</div>
+			</a>
+			
+			<ul id="toc-Presentation_broadcast_on_CBS-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Presentation_broadcast_on_TNT"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Presentation_broadcast_on_TNT">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">3.2</span>
+					<span>Presentation broadcast on TNT</span>
+				</div>
+			</a>
+			
+			<ul id="toc-Presentation_broadcast_on_TNT-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+		<li id="toc-Presentation_broadcast_on_TNT_UK"
+			class="vector-toc-list-item vector-toc-level-2">
+			<a class="vector-toc-link" href="#Presentation_broadcast_on_TNT_UK">
+				<div class="vector-toc-text">
+					<span class="vector-toc-numb">3.3</span>
+					<span>Presentation broadcast on TNT UK</span>
+				</div>
+			</a>
+			
+			<ul id="toc-Presentation_broadcast_on_TNT_UK-sublist" class="vector-toc-list">
+			</ul>
+		</li>
+	</ul>
+	</li>
+	<li id="toc-Criticisms"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#Criticisms">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">4</span>
+				<span>Criticisms</span>
+			</div>
+		</a>
+		
+		<ul id="toc-Criticisms-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-See_also"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#See_also">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">5</span>
+				<span>See also</span>
+			</div>
+		</a>
+		
+		<ul id="toc-See_also-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-References"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#References">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">6</span>
+				<span>References</span>
+			</div>
+		</a>
+		
+		<ul id="toc-References-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+	<li id="toc-External_links"
+		class="vector-toc-list-item vector-toc-level-1 vector-toc-list-item-expanded">
+		<a class="vector-toc-link" href="#External_links">
+			<div class="vector-toc-text">
+				<span class="vector-toc-numb">7</span>
+				<span>External links</span>
+			</div>
+		</a>
+		
+		<ul id="toc-External_links-sublist" class="vector-toc-list">
+		</ul>
+	</li>
+</ul>
+</div>
+
+					</div>
+		</nav>
+			</div>
+		</div>
+		<div class="mw-content-container">
+			<main id="content" class="mw-body">
+				<header class="mw-body-header vector-page-titlebar">
+					<nav aria-label="Contents" class="vector-toc-landmark">
+						
+<div id="vector-page-titlebar-toc" class="vector-dropdown vector-page-titlebar-toc vector-button-flush-left"  >
+	<input type="checkbox" id="vector-page-titlebar-toc-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-titlebar-toc" class="vector-dropdown-checkbox "  aria-label="Toggle the table of contents"  >
+	<label id="vector-page-titlebar-toc-label" for="vector-page-titlebar-toc-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-listBullet mw-ui-icon-wikimedia-listBullet"></span>
+
+<span class="vector-dropdown-label-text">Toggle the table of contents</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+							<div id="vector-page-titlebar-toc-unpinned-container" class="vector-unpinned-container">
+			</div>
+		
+	</div>
+</div>
+
+					</nav>
+					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span class="mw-page-title-main">AFI's 100 Years...100 Movies</span></h1>
+							
+<div id="p-lang-btn" class="vector-dropdown mw-portlet mw-portlet-lang"  >
+	<input type="checkbox" id="p-lang-btn-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-p-lang-btn" class="vector-dropdown-checkbox mw-interlanguage-selector" aria-label="Go to an article in another language. Available in 36 languages"   >
+	<label id="p-lang-btn-label" for="p-lang-btn-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--action-progressive mw-portlet-lang-heading-36" aria-hidden="true"  ><span class="vector-icon mw-ui-icon-language-progressive mw-ui-icon-wikimedia-language-progressive"></span>
+
+<span class="vector-dropdown-label-text">36 languages</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+		<div class="vector-menu-content">
+			
+			<ul class="vector-menu-content-list">
+				
+				<li class="interlanguage-link interwiki-af mw-list-item"><a href="https://af.wikipedia.org/wiki/AFI%27s_100_Years..._100_Movies" title="AFI&#039;s 100 Years... 100 Movies – Afrikaans" lang="af" hreflang="af" class="interlanguage-link-target"><span>Afrikaans</span></a></li><li class="interlanguage-link interwiki-ar mw-list-item"><a href="https://ar.wikipedia.org/wiki/%D9%85%D8%B9%D9%87%D8%AF_%D8%A7%D9%84%D9%81%D9%8A%D9%84%D9%85_%D8%A7%D9%84%D8%A3%D9%85%D8%B1%D9%8A%D9%83%D9%8A_100_%D8%B9%D8%A7%D9%85_%D9%88100_%D9%81%D9%8A%D9%84%D9%85" title="معهد الفيلم الأمريكي 100 عام و100 فيلم – Arabic" lang="ar" hreflang="ar" class="interlanguage-link-target"><span>العربية</span></a></li><li class="interlanguage-link interwiki-bg mw-list-item"><a href="https://bg.wikipedia.org/wiki/100_%D0%B3%D0%BE%D0%B4%D0%B8%D0%BD%D0%B8_%D0%90%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D0%BA%D0%B8_%D1%84%D0%B8%D0%BB%D0%BC%D0%BE%D0%B2_%D0%B8%D0%BD%D1%81%D1%82%D0%B8%D1%82%D1%83%D1%82..._100_%D1%84%D0%B8%D0%BB%D0%BC%D0%B0" title="100 години Американски филмов институт... 100 филма – Bulgarian" lang="bg" hreflang="bg" class="interlanguage-link-target"><span>Български</span></a></li><li class="interlanguage-link interwiki-ca mw-list-item"><a href="https://ca.wikipedia.org/wiki/Top_100_de_l%27American_Film_Institute" title="Top 100 de l&#039;American Film Institute – Catalan" lang="ca" hreflang="ca" class="interlanguage-link-target"><span>Català</span></a></li><li class="interlanguage-link interwiki-et mw-list-item"><a href="https://et.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies" title="AFI&#039;s 100 Years...100 Movies – Estonian" lang="et" hreflang="et" class="interlanguage-link-target"><span>Eesti</span></a></li><li class="interlanguage-link interwiki-el mw-list-item"><a href="https://el.wikipedia.org/wiki/AFI_100_%CE%A7%CF%81%CF%8C%CE%BD%CE%B9%CE%B1..._100_%CE%A4%CE%B1%CE%B9%CE%BD%CE%AF%CE%B5%CF%82" title="AFI 100 Χρόνια... 100 Ταινίες – Greek" lang="el" hreflang="el" class="interlanguage-link-target"><span>Ελληνικά</span></a></li><li class="interlanguage-link interwiki-es mw-list-item"><a href="https://es.wikipedia.org/wiki/Anexo:AFI%27s_100_a%C3%B1os..._100_pel%C3%ADculas" title="Anexo:AFI&#039;s 100 años... 100 películas – Spanish" lang="es" hreflang="es" class="interlanguage-link-target"><span>Español</span></a></li><li class="interlanguage-link interwiki-fa mw-list-item"><a href="https://fa.wikipedia.org/wiki/%DB%B1%DB%B0%DB%B0_%D8%B3%D8%A7%D9%84%E2%80%A6_%DB%B1%DB%B0%DB%B0_%D9%81%DB%8C%D9%84%D9%85_%D8%A8%D9%87_%D8%A7%D9%86%D8%AA%D8%AE%D8%A7%D8%A8_%D8%A8%D9%81%D8%A7" title="۱۰۰ سال… ۱۰۰ فیلم به انتخاب بفا – Persian" lang="fa" hreflang="fa" class="interlanguage-link-target"><span>فارسی</span></a></li><li class="interlanguage-link interwiki-fr mw-list-item"><a href="https://fr.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies" title="AFI&#039;s 100 Years...100 Movies – French" lang="fr" hreflang="fr" class="interlanguage-link-target"><span>Français</span></a></li><li class="interlanguage-link interwiki-gl mw-list-item"><a href="https://gl.wikipedia.org/wiki/Lista_das_mellores_pel%C3%ADculas_estadounidenses_segundo_o_American_Film_Institute" title="Lista das mellores películas estadounidenses segundo o American Film Institute – Galician" lang="gl" hreflang="gl" class="interlanguage-link-target"><span>Galego</span></a></li><li class="interlanguage-link interwiki-ko mw-list-item"><a href="https://ko.wikipedia.org/wiki/AFI_%EC%84%A0%EC%A0%95_100%EB%8C%80_%EC%98%81%ED%99%94" title="AFI 선정 100대 영화 – Korean" lang="ko" hreflang="ko" class="interlanguage-link-target"><span>한국어</span></a></li><li class="interlanguage-link interwiki-hy mw-list-item"><a href="https://hy.wikipedia.org/wiki/%D4%B1%D5%B4%D5%A5%D6%80%D5%AB%D5%AF%D5%B5%D5%A1%D5%B6_%D5%A2%D5%B8%D5%AC%D5%B8%D6%80_%D5%AA%D5%A1%D5%B4%D5%A1%D5%B6%D5%A1%D5%AF%D5%B6%D5%A5%D6%80%D5%AB_100_%D5%AC%D5%A1%D5%BE%D5%A1%D5%A3%D5%B8%D6%82%D5%B5%D5%B6_%D6%86%D5%AB%D5%AC%D5%B4%D5%A5%D6%80" title="Ամերիկյան բոլոր ժամանակների 100 լավագույն ֆիլմեր – Armenian" lang="hy" hreflang="hy" class="interlanguage-link-target"><span>Հայերեն</span></a></li><li class="interlanguage-link interwiki-hr mw-list-item"><a href="https://hr.wikipedia.org/wiki/100_godina_AFI-ja..._100_filmova" title="100 godina AFI-ja... 100 filmova – Croatian" lang="hr" hreflang="hr" class="interlanguage-link-target"><span>Hrvatski</span></a></li><li class="interlanguage-link interwiki-id mw-list-item"><a href="https://id.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies" title="AFI&#039;s 100 Years...100 Movies – Indonesian" lang="id" hreflang="id" class="interlanguage-link-target"><span>Bahasa Indonesia</span></a></li><li class="interlanguage-link interwiki-it mw-list-item"><a href="https://it.wikipedia.org/wiki/AFI%27s_100_Years..._100_Movies" title="AFI&#039;s 100 Years... 100 Movies – Italian" lang="it" hreflang="it" class="interlanguage-link-target"><span>Italiano</span></a></li><li class="interlanguage-link interwiki-he mw-list-item"><a href="https://he.wikipedia.org/wiki/%D7%9E%D7%90%D7%94_%D7%A9%D7%A0%D7%99%D7%9D..._%D7%9E%D7%90%D7%94_%D7%A1%D7%A8%D7%98%D7%99%D7%9D" title="מאה שנים... מאה סרטים – Hebrew" lang="he" hreflang="he" class="interlanguage-link-target"><span>עברית</span></a></li><li class="interlanguage-link interwiki-la mw-list-item"><a href="https://la.wikipedia.org/wiki/Centum_celeberrimae_pelliculae" title="Centum celeberrimae pelliculae – Latin" lang="la" hreflang="la" class="interlanguage-link-target"><span>Latina</span></a></li><li class="interlanguage-link interwiki-lv mw-list-item"><a href="https://lv.wikipedia.org/wiki/AFI_100_gadi..._100_filmas" title="AFI 100 gadi... 100 filmas – Latvian" lang="lv" hreflang="lv" class="interlanguage-link-target"><span>Latviešu</span></a></li><li class="interlanguage-link interwiki-hu mw-list-item"><a href="https://hu.wikipedia.org/wiki/Minden_id%C5%91k_100_legjobb_amerikai_filmje" title="Minden idők 100 legjobb amerikai filmje – Hungarian" lang="hu" hreflang="hu" class="interlanguage-link-target"><span>Magyar</span></a></li><li class="interlanguage-link interwiki-nl mw-list-item"><a href="https://nl.wikipedia.org/wiki/AFI%27s_100_Years..._100_Movies" title="AFI&#039;s 100 Years... 100 Movies – Dutch" lang="nl" hreflang="nl" class="interlanguage-link-target"><span>Nederlands</span></a></li><li class="interlanguage-link interwiki-ja mw-list-item"><a href="https://ja.wikipedia.org/wiki/%E3%82%A2%E3%83%A1%E3%83%AA%E3%82%AB%E6%98%A0%E7%94%BB%E3%83%99%E3%82%B9%E3%83%88100" title="アメリカ映画ベスト100 – Japanese" lang="ja" hreflang="ja" class="interlanguage-link-target"><span>日本語</span></a></li><li class="interlanguage-link interwiki-no mw-list-item"><a href="https://no.wikipedia.org/wiki/AFI%E2%80%99s_100_Years%E2%80%A6100_Movies" title="AFI’s 100 Years…100 Movies – Norwegian Bokmål" lang="nb" hreflang="nb" class="interlanguage-link-target"><span>Norsk bokmål</span></a></li><li class="interlanguage-link interwiki-pl mw-list-item"><a href="https://pl.wikipedia.org/wiki/Lista_stu_najlepszych_ameryka%C5%84skich_film%C3%B3w_wed%C5%82ug_AFI" title="Lista stu najlepszych amerykańskich filmów według AFI – Polish" lang="pl" hreflang="pl" class="interlanguage-link-target"><span>Polski</span></a></li><li class="interlanguage-link interwiki-pt mw-list-item"><a href="https://pt.wikipedia.org/wiki/Lista_dos_melhores_filmes_estadunidenses_segundo_o_American_Film_Institute" title="Lista dos melhores filmes estadunidenses segundo o American Film Institute – Portuguese" lang="pt" hreflang="pt" class="interlanguage-link-target"><span>Português</span></a></li><li class="interlanguage-link interwiki-ro mw-list-item"><a href="https://ro.wikipedia.org/wiki/100_de_ani...100_de_filme" title="100 de ani...100 de filme – Romanian" lang="ro" hreflang="ro" class="interlanguage-link-target"><span>Română</span></a></li><li class="interlanguage-link interwiki-ru badge-Q17506997 badge-featuredlist mw-list-item" title="featured list badge"><a href="https://ru.wikipedia.org/wiki/100_%D0%BB%D1%83%D1%87%D1%88%D0%B8%D1%85_%D0%B0%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D1%85_%D1%84%D0%B8%D0%BB%D1%8C%D0%BC%D0%BE%D0%B2_%D0%B7%D0%B0_100_%D0%BB%D0%B5%D1%82_%D0%BF%D0%BE_%D0%B2%D0%B5%D1%80%D1%81%D0%B8%D0%B8_AFI" title="100 лучших американских фильмов за 100 лет по версии AFI – Russian" lang="ru" hreflang="ru" class="interlanguage-link-target"><span>Русский</span></a></li><li class="interlanguage-link interwiki-simple mw-list-item"><a href="https://simple.wikipedia.org/wiki/AFI%27s_100_Years..._100_Movies" title="AFI&#039;s 100 Years... 100 Movies – Simple English" lang="en-simple" hreflang="en-simple" class="interlanguage-link-target"><span>Simple English</span></a></li><li class="interlanguage-link interwiki-sl mw-list-item"><a href="https://sl.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies" title="AFI&#039;s 100 Years...100 Movies – Slovenian" lang="sl" hreflang="sl" class="interlanguage-link-target"><span>Slovenščina</span></a></li><li class="interlanguage-link interwiki-sr mw-list-item"><a href="https://sr.wikipedia.org/wiki/100_%D0%B3%D0%BE%D0%B4%D0%B8%D0%BD%D0%B0_%D0%90%D0%A4%D0%98-%D1%98%D0%B0..._100_%D1%84%D0%B8%D0%BB%D0%BC%D0%BE%D0%B2%D0%B0" title="100 година АФИ-ја... 100 филмова – Serbian" lang="sr" hreflang="sr" class="interlanguage-link-target"><span>Српски / srpski</span></a></li><li class="interlanguage-link interwiki-sh mw-list-item"><a href="https://sh.wikipedia.org/wiki/100_godina_AFI-ja..._100_filmova" title="100 godina AFI-ja... 100 filmova – Serbo-Croatian" lang="sh" hreflang="sh" class="interlanguage-link-target"><span>Srpskohrvatski / српскохрватски</span></a></li><li class="interlanguage-link interwiki-fi mw-list-item"><a href="https://fi.wikipedia.org/wiki/AFI:n_100-vuotissarjan_100_parasta_elokuvaa" title="AFI:n 100-vuotissarjan 100 parasta elokuvaa – Finnish" lang="fi" hreflang="fi" class="interlanguage-link-target"><span>Suomi</span></a></li><li class="interlanguage-link interwiki-sv mw-list-item"><a href="https://sv.wikipedia.org/wiki/AFI%27s_100_Years...100_Movies" title="AFI&#039;s 100 Years...100 Movies – Swedish" lang="sv" hreflang="sv" class="interlanguage-link-target"><span>Svenska</span></a></li><li class="interlanguage-link interwiki-tr mw-list-item"><a href="https://tr.wikipedia.org/wiki/AFI%27n%C4%B1n_100_Y%C4%B1l%C4%B1..._100_Film" title="AFI&#039;nın 100 Yılı... 100 Film – Turkish" lang="tr" hreflang="tr" class="interlanguage-link-target"><span>Türkçe</span></a></li><li class="interlanguage-link interwiki-uk mw-list-item"><a href="https://uk.wikipedia.org/wiki/100_%D0%BD%D0%B0%D0%B9%D0%BA%D1%80%D0%B0%D1%89%D0%B8%D1%85_%D0%B0%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D1%85_%D1%84%D1%96%D0%BB%D1%8C%D0%BC%D1%96%D0%B2_%D0%B7%D0%B0_100_%D1%80%D0%BE%D0%BA%D1%96%D0%B2_%D0%B7%D0%B0_%D0%B2%D0%B5%D1%80%D1%81%D1%96%D1%94%D1%8E_AFI" title="100 найкращих американських фільмів за 100 років за версією AFI – Ukrainian" lang="uk" hreflang="uk" class="interlanguage-link-target"><span>Українська</span></a></li><li class="interlanguage-link interwiki-vi mw-list-item"><a href="https://vi.wikipedia.org/wiki/Danh_s%C3%A1ch_100_phim_hay_nh%E1%BA%A5t_c%E1%BB%A7a_Vi%E1%BB%87n_phim_M%E1%BB%B9" title="Danh sách 100 phim hay nhất của Viện phim Mỹ – Vietnamese" lang="vi" hreflang="vi" class="interlanguage-link-target"><span>Tiếng Việt</span></a></li><li class="interlanguage-link interwiki-zh mw-list-item"><a href="https://zh.wikipedia.org/wiki/AFI%E7%99%BE%E5%B9%B4%E7%99%BE%E5%A4%A7%E9%9B%BB%E5%BD%B1" title="AFI百年百大電影 – Chinese" lang="zh" hreflang="zh" class="interlanguage-link-target"><span>中文</span></a></li>
+			</ul>
+			<div class="after-portlet after-portlet-lang"><span class="wb-langlinks-edit wb-langlinks-link"><a href="https://www.wikidata.org/wiki/Special:EntityPage/Q719345#sitelinks-wikipedia" title="Edit interlanguage links" class="wbc-editpage">Edit links</a></span></div>
+		</div>
+
+	</div>
+</div>
+</header>
+				<div class="vector-page-toolbar">
+					<div class="vector-page-toolbar-container">
+						<div id="left-navigation">
+							<nav aria-label="Namespaces">
+								
+<div id="p-associated-pages" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-associated-pages"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/AFI%27s_100_Years...100_Movies" title="View the content page [c]" accesskey="c"><span>Article</span></a></li><li id="ca-talk" class="vector-tab-noicon mw-list-item"><a href="/wiki/Talk:AFI%27s_100_Years...100_Movies" rel="discussion" title="Discuss improvements to the content page [t]" accesskey="t"><span>Talk</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+								
+<div id="vector-variants-dropdown" class="vector-dropdown emptyPortlet"  >
+	<input type="checkbox" id="vector-variants-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-variants-dropdown" class="vector-dropdown-checkbox " aria-label="Change language variant"   >
+	<label id="vector-variants-dropdown-label" for="vector-variants-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">English</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+					
+<div id="p-variants" class="vector-menu mw-portlet mw-portlet-variants emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+						<div id="right-navigation" class="vector-collapsible">
+							<nav aria-label="Views">
+								
+<div id="p-views" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-views"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-view" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/AFI%27s_100_Years...100_Movies"><span>Read</span></a></li><li id="ca-edit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit" title="Edit this page [e]" accesskey="e"><span>Edit</span></a></li><li id="ca-history" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=history" title="Past revisions of this page [h]" accesskey="h"><span>View history</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+							</nav>
+				
+							<nav class="vector-page-tools-landmark" aria-label="Page tools">
+								
+<div id="vector-page-tools-dropdown" class="vector-dropdown vector-page-tools-dropdown"  >
+	<input type="checkbox" id="vector-page-tools-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-tools-dropdown" class="vector-dropdown-checkbox "  aria-label="Tools"  >
+	<label id="vector-page-tools-dropdown-label" for="vector-page-tools-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">Tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+									<div id="vector-page-tools-unpinned-container" class="vector-unpinned-container">
+						
+<div id="vector-page-tools" class="vector-page-tools vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-page-tools-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="page-tools-pinned"
+	data-pinnable-element-id="vector-page-tools"
+	data-pinned-container-id="vector-page-tools-pinned-container"
+	data-unpinned-container-id="vector-page-tools-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Tools</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-page-tools.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-page-tools.unpin">hide</button>
+</div>
+
+	
+<div id="p-cactions" class="vector-menu mw-portlet mw-portlet-cactions emptyPortlet vector-has-collapsible-items"  title="More options" >
+	<div class="vector-menu-heading">
+		Actions
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-more-view" class="selected vector-more-collapsible-item mw-list-item"><a href="/wiki/AFI%27s_100_Years...100_Movies"><span>Read</span></a></li><li id="ca-more-edit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit" title="Edit this page [e]" accesskey="e"><span>Edit</span></a></li><li id="ca-more-history" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=history"><span>View history</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-tb" class="vector-menu mw-portlet mw-portlet-tb"  >
+	<div class="vector-menu-heading">
+		General
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Special:WhatLinksHere/AFI%27s_100_Years...100_Movies" title="List of all English Wikipedia pages containing links to this page [j]" accesskey="j"><span>What links here</span></a></li><li id="t-recentchangeslinked" class="mw-list-item"><a href="/wiki/Special:RecentChangesLinked/AFI%27s_100_Years...100_Movies" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k"><span>Related changes</span></a></li><li id="t-upload" class="mw-list-item"><a href="/wiki/Wikipedia:File_Upload_Wizard" title="Upload files [u]" accesskey="u"><span>Upload file</span></a></li><li id="t-specialpages" class="mw-list-item"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q"><span>Special pages</span></a></li><li id="t-permalink" class="mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;oldid=1217354641" title="Permanent link to this revision of this page"><span>Permanent link</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=info" title="More information about this page"><span>Page information</span></a></li><li id="t-cite" class="mw-list-item"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=AFI%27s_100_Years...100_Movies&amp;id=1217354641&amp;wpFormIdentifier=titleform" title="Information on how to cite this page"><span>Cite this page</span></a></li><li id="t-urlshortener" class="mw-list-item"><a href="/w/index.php?title=Special:UrlShortener&amp;url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FAFI%2527s_100_Years...100_Movies"><span>Get shortened URL</span></a></li><li id="t-urlshortener-qrcode" class="mw-list-item"><a href="/w/index.php?title=Special:QrCode&amp;url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FAFI%2527s_100_Years...100_Movies"><span>Download QR code</span></a></li><li id="t-wikibase" class="mw-list-item"><a href="https://www.wikidata.org/wiki/Special:EntityPage/Q719345" title="Structured data on this page hosted by Wikidata [g]" accesskey="g"><span>Wikidata item</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-coll-print_export" class="vector-menu mw-portlet mw-portlet-coll-print_export"  >
+	<div class="vector-menu-heading">
+		Print/export
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="coll-download-as-rl" class="mw-list-item"><a href="/w/index.php?title=Special:DownloadAsPdf&amp;page=AFI%27s_100_Years...100_Movies&amp;action=show-download-screen" title="Download this page as a PDF file"><span>Download as PDF</span></a></li><li id="t-print" class="mw-list-item"><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;printable=yes" title="Printable version of this page [p]" accesskey="p"><span>Printable version</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+									</div>
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+					</div>
+				</div>
+				<div class="vector-column-end">
+					<div class="vector-sticky-pinned-container">
+						<nav class="vector-page-tools-landmark" aria-label="Page tools">
+							<div id="vector-page-tools-pinned-container" class="vector-pinned-container">
+				
+							</div>
+		</nav>
+						<nav class="vector-appearance-landmark" aria-label="Appearance">
+							<div id="vector-appearance-pinned-container" class="vector-pinned-container">
+				<div id="vector-appearance" class="vector-appearance vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-appearance-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="appearance-pinned"
+	data-pinnable-element-id="vector-appearance"
+	data-pinned-container-id="vector-appearance-pinned-container"
+	data-unpinned-container-id="vector-appearance-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Appearance</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-appearance.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-appearance.unpin">hide</button>
+</div>
+
+
+</div>
+
+							</div>
+		</nav>
+					</div>
+				</div>
+				<div id="bodyContent" class="vector-body" aria-labelledby="firstHeading" data-mw-ve-target-container>
+					<div class="vector-body-before-content">
+							<div class="mw-indicators">
+		</div>
+
+						<div id="siteSub" class="noprint">From Wikipedia, the free encyclopedia</div>
+					</div>
+					<div id="contentSub"><div id="mw-content-subtitle"></div></div>
+					
+					
+					<div id="mw-content-text" class="mw-body-content"><div class="mw-content-ltr mw-parser-output" lang="en" dir="ltr"><div class="shortdescription nomobile noexcerpt noprint searchaux" style="display:none">List of 100 milestones in American cinematic history</div>
+<style data-mw-deduplicate="TemplateStyles:r1229112069">.mw-parser-output .infobox-subbox{padding:0;border:none;margin:-3px;width:auto;min-width:100%;font-size:100%;clear:none;float:none;background-color:transparent}.mw-parser-output .infobox-3cols-child{margin:auto}.mw-parser-output .infobox .navbar{font-size:100%}body.skin-minerva .mw-parser-output .infobox-header,body.skin-minerva .mw-parser-output .infobox-subheader,body.skin-minerva .mw-parser-output .infobox-above,body.skin-minerva .mw-parser-output .infobox-title,body.skin-minerva .mw-parser-output .infobox-image,body.skin-minerva .mw-parser-output .infobox-full-data,body.skin-minerva .mw-parser-output .infobox-below{text-align:center}html.skin-theme-clientpref-night .mw-parser-output .infobox-full-data:not(.notheme)>div:not(.notheme)[style]{background:#1f1f23!important;color:#f8f9fa}@media(prefers-color-scheme:dark){html.skin-theme-clientpref-os .mw-parser-output .infobox-full-data:not(.notheme) div:not(.notheme){background:#1f1f23!important;color:#f8f9fa}}@media(min-width:640px){body.skin--responsive .mw-parser-output .infobox-table{display:table!important}body.skin--responsive .mw-parser-output .infobox-table>caption{display:table-caption!important}body.skin--responsive .mw-parser-output .infobox-table>tbody{display:table-row-group}body.skin--responsive .mw-parser-output .infobox-table tr{display:table-row!important}body.skin--responsive .mw-parser-output .infobox-table th,body.skin--responsive .mw-parser-output .infobox-table td{padding-left:inherit;padding-right:inherit}}</style><table class="infobox"><caption class="infobox-title"><a href="/wiki/AFI_100_Years..._series" title="AFI 100 Years... series">AFI 100 Years... series</a></caption><tbody><tr><th scope="row" class="infobox-label">1998</th><td class="infobox-data"><i><b><a class="mw-selflink selflink">100 Movies</a></b></i></td></tr><tr><th scope="row" class="infobox-label">1999</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Stars" title="AFI&#39;s 100 Years...100 Stars">100 Stars</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2000</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Laughs" title="AFI&#39;s 100 Years...100 Laughs">100 Laughs</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2001</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Thrills" title="AFI&#39;s 100 Years...100 Thrills">100 Thrills</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2002</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Passions" title="AFI&#39;s 100 Years...100 Passions">100 Passions</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2003</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Heroes_%26_Villains" title="AFI&#39;s 100 Years...100 Heroes &amp; Villains">100 Heroes &amp; Villains</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2004</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Songs" title="AFI&#39;s 100 Years...100 Songs">100 Songs</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2005</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Movie_Quotes" title="AFI&#39;s 100 Years...100 Movie Quotes">100 Movie Quotes</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2005</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years_of_Film_Scores" title="AFI&#39;s 100 Years of Film Scores">25 Scores</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2006</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Cheers" title="AFI&#39;s 100 Years...100 Cheers">100 Cheers</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2006</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_Greatest_Movie_Musicals" title="AFI&#39;s Greatest Movie Musicals">25 Musicals</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2007</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_100_Years...100_Movies_(10th_Anniversary_Edition)" title="AFI&#39;s 100 Years...100 Movies (10th Anniversary Edition)">100 Movies (Updated)</a></b></i></td></tr><tr><th scope="row" class="infobox-label">2008</th><td class="infobox-data"><i><b><a href="/wiki/AFI%27s_10_Top_10" title="AFI&#39;s 10 Top 10">AFI's 10 Top 10</a></b></i></td></tr><tr><td colspan="2" class="infobox-navbar"><style data-mw-deduplicate="TemplateStyles:r1129693374">.mw-parser-output .hlist dl,.mw-parser-output .hlist ol,.mw-parser-output .hlist ul{margin:0;padding:0}.mw-parser-output .hlist dd,.mw-parser-output .hlist dt,.mw-parser-output .hlist li{margin:0;display:inline}.mw-parser-output .hlist.inline,.mw-parser-output .hlist.inline dl,.mw-parser-output .hlist.inline ol,.mw-parser-output .hlist.inline ul,.mw-parser-output .hlist dl dl,.mw-parser-output .hlist dl ol,.mw-parser-output .hlist dl ul,.mw-parser-output .hlist ol dl,.mw-parser-output .hlist ol ol,.mw-parser-output .hlist ol ul,.mw-parser-output .hlist ul dl,.mw-parser-output .hlist ul ol,.mw-parser-output .hlist ul ul{display:inline}.mw-parser-output .hlist .mw-empty-li{display:none}.mw-parser-output .hlist dt::after{content:": "}.mw-parser-output .hlist dd::after,.mw-parser-output .hlist li::after{content:" · ";font-weight:bold}.mw-parser-output .hlist dd:last-child::after,.mw-parser-output .hlist dt:last-child::after,.mw-parser-output .hlist li:last-child::after{content:none}.mw-parser-output .hlist dd dd:first-child::before,.mw-parser-output .hlist dd dt:first-child::before,.mw-parser-output .hlist dd li:first-child::before,.mw-parser-output .hlist dt dd:first-child::before,.mw-parser-output .hlist dt dt:first-child::before,.mw-parser-output .hlist dt li:first-child::before,.mw-parser-output .hlist li dd:first-child::before,.mw-parser-output .hlist li dt:first-child::before,.mw-parser-output .hlist li li:first-child::before{content:" (";font-weight:normal}.mw-parser-output .hlist dd dd:last-child::after,.mw-parser-output .hlist dd dt:last-child::after,.mw-parser-output .hlist dd li:last-child::after,.mw-parser-output .hlist dt dd:last-child::after,.mw-parser-output .hlist dt dt:last-child::after,.mw-parser-output .hlist dt li:last-child::after,.mw-parser-output .hlist li dd:last-child::after,.mw-parser-output .hlist li dt:last-child::after,.mw-parser-output .hlist li li:last-child::after{content:")";font-weight:normal}.mw-parser-output .hlist ol{counter-reset:listitem}.mw-parser-output .hlist ol>li{counter-increment:listitem}.mw-parser-output .hlist ol>li::before{content:" "counter(listitem)"\a0 "}.mw-parser-output .hlist dd ol>li:first-child::before,.mw-parser-output .hlist dt ol>li:first-child::before,.mw-parser-output .hlist li ol>li:first-child::before{content:" ("counter(listitem)"\a0 "}</style><style data-mw-deduplicate="TemplateStyles:r1063604349">.mw-parser-output .navbar{display:inline;font-size:88%;font-weight:normal}.mw-parser-output .navbar-collapse{float:left;text-align:left}.mw-parser-output .navbar-boxtext{word-spacing:0}.mw-parser-output .navbar ul{display:inline-block;white-space:nowrap;line-height:inherit}.mw-parser-output .navbar-brackets::before{margin-right:-0.125em;content:"[ "}.mw-parser-output .navbar-brackets::after{margin-left:-0.125em;content:" ]"}.mw-parser-output .navbar li{word-spacing:-0.125em}.mw-parser-output .navbar a>span,.mw-parser-output .navbar a>abbr{text-decoration:inherit}.mw-parser-output .navbar-mini abbr{font-variant:small-caps;border-bottom:none;text-decoration:none;cursor:inherit}.mw-parser-output .navbar-ct-full{font-size:114%;margin:0 7em}.mw-parser-output .navbar-ct-mini{font-size:114%;margin:0 4em}</style><div class="navbar plainlinks hlist navbar-mini"><ul><li class="nv-view"><a href="/wiki/Template:AFI_100_Years..._series" title="Template:AFI 100 Years... series"><abbr title="View this template">v</abbr></a></li><li class="nv-talk"><a href="/wiki/Template_talk:AFI_100_Years..._series" title="Template talk:AFI 100 Years... series"><abbr title="Discuss this template">t</abbr></a></li><li class="nv-edit"><a href="/wiki/Special:EditPage/Template:AFI_100_Years..._series" title="Special:EditPage/Template:AFI 100 Years... series"><abbr title="Edit this template">e</abbr></a></li></ul></div></td></tr></tbody></table>
+<p>The first of the <a href="/wiki/AFI_100_Years..._series" title="AFI 100 Years... series">AFI 100 Years... series</a> of cinematic milestones, <b>AFI's 100 Years... 100 American Movies</b> is a list of the 100 best <a href="/wiki/Cinema_of_the_United_States" title="Cinema of the United States">American movies</a>, as determined by the <a href="/wiki/American_Film_Institute" title="American Film Institute">American Film Institute</a> from a poll of more than 1,500 artists and leaders in the <a href="/wiki/Film_industry" title="Film industry">film industry</a> who chose from a list of 400 nominated movies. The 100-best list American films was unveiled in 1998. AFI released an <a href="/wiki/AFI%27s_100_Years...100_Movies_(10th_Anniversary_Edition)" title="AFI&#39;s 100 Years...100 Movies (10th Anniversary Edition)">updated list</a> in 2007.
+</p>
+<meta property="mw:PageProp/toc" />
+<h2><span class="mw-headline" id="Criteria">Criteria</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=1" title="Edit section: Criteria"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>Films were judged according to the following criteria:
+</p>
+<ol><li><i><a href="/wiki/Feature_length" class="mw-redirect" title="Feature length">Feature length</a></i>: Narrative format, at least 60 minutes long.</li>
+<li><i><a href="/wiki/Cinema_of_the_United_States" title="Cinema of the United States">American film</a></i>: <a href="/wiki/English_language" title="English language">English language</a>, with significant creative and/or financial production elements from the <a href="/wiki/United_States" title="United States">United States</a>.  (Certain films, notably <i><a href="/wiki/The_Bridge_on_the_River_Kwai" title="The Bridge on the River Kwai">The Bridge on the River Kwai</a></i>, <i><a href="/wiki/2001:_A_Space_Odyssey" title="2001: A Space Odyssey">2001: A Space Odyssey</a></i> and <i><a href="/wiki/Lawrence_of_Arabia_(film)" title="Lawrence of Arabia (film)">Lawrence of Arabia</a></i>, were British-made but funded and distributed by American studios. <i>The Lord of the Rings</i> was New Zealand-made with American funding.)</li>
+<li><i>Critical recognition</i>: Formal commendation in print.</li>
+<li><i>Major award winner</i>: Recognition from competitive events including awards from organizations in the film community and major film festivals.</li>
+<li><i>Popularity over time</i>: Including figures for box office adjusted for inflation, television broadcasts and syndication, and home video sales and rentals.</li>
+<li><i>Historical significance</i>: A film's mark on the history of the moving image through technical innovation, visionary narrative devices or other groundbreaking achievements.</li>
+<li><i>Cultural impact</i>: A film's mark on American society in matters of style and substance.</li></ol>
+<p><sup id="cite_ref-1" class="reference"><a href="#cite_note-1">&#91;1&#93;</a></sup>
+</p>
+<h2><span class="mw-headline" id="List">List</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=2" title="Edit section: List"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<table class="wikitable sortable" style="font-size:1.00em; line-height:1.5em;">
+<tbody><tr>
+<th>Film</th>
+<th>Release year</th>
+<th>Director</th>
+<th>Production companies</th>
+<th>1998 Rank</th>
+<th>2007 Rank
+</th></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Citizen_Kane" title="Citizen Kane">Citizen Kane</a></i></td>
+<td>1941</td>
+<td><span data-sort-value="Welles&#160;!"><a href="/wiki/Orson_Welles" title="Orson Welles">Orson Welles</a></span></td>
+<td><a href="/wiki/RKO_Radio_Pictures" class="mw-redirect" title="RKO Radio Pictures">RKO Radio Pictures</a></td>
+<td>1</td>
+<td>1
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Casablanca_(film)" title="Casablanca (film)">Casablanca</a></i></td>
+<td>1942</td>
+<td><span data-sort-value="Curtiz&#160;!"><a href="/wiki/Michael_Curtiz" title="Michael Curtiz">Michael Curtiz</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>2</td>
+<td>3
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Godfather&#160;!"><i><a href="/wiki/The_Godfather" title="The Godfather">The Godfather</a></i></span></td>
+<td>1972</td>
+<td><span data-sort-value="Coppola&#160;!"><a href="/wiki/Francis_Ford_Coppola" title="Francis Ford Coppola">Francis Ford Coppola</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a>, Alfran Productions</td>
+<td>3</td>
+<td>2
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Gone_with_the_Wind_(film)" title="Gone with the Wind (film)">Gone with the Wind</a></i></td>
+<td>1939</td>
+<td><span data-sort-value="Fleming&#160;!"><a href="/wiki/Victor_Fleming" title="Victor Fleming">Victor Fleming</a></span></td>
+<td><a href="/wiki/Selznick_International_Pictures" title="Selznick International Pictures">Selznick International Pictures</a></td>
+<td>4</td>
+<td>6
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Lawrence_of_Arabia_(film)" title="Lawrence of Arabia (film)">Lawrence of Arabia</a></i></td>
+<td>1962</td>
+<td><span data-sort-value="Lean&#160;!"><a href="/wiki/David_Lean" title="David Lean">David Lean</a></span></td>
+<td><a href="/wiki/Horizon_Pictures" title="Horizon Pictures">Horizon Pictures</a></td>
+<td>5</td>
+<td>7
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Wizard of Oz&#160;!"><i><a href="/wiki/The_Wizard_of_Oz" title="The Wizard of Oz">The Wizard of Oz</a></i></span></td>
+<td>1939</td>
+<td><span data-sort-value="Fleming&#160;!"><a href="/wiki/Victor_Fleming" title="Victor Fleming">Victor Fleming</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>6</td>
+<td>10
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Graduate&#160;!"><i><a href="/wiki/The_Graduate" title="The Graduate">The Graduate</a></i></span></td>
+<td>1967</td>
+<td><span data-sort-value="Nichols&#160;!"><a href="/wiki/Mike_Nichols" title="Mike Nichols">Mike Nichols</a></span></td>
+<td><a href="/wiki/Lawrence_Turman" title="Lawrence Turman">Lawrence Turman</a></td>
+<td>7</td>
+<td>17
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/On_the_Waterfront" title="On the Waterfront">On the Waterfront</a></i></td>
+<td>1954</td>
+<td><span data-sort-value="Kazan&#160;!"><a href="/wiki/Elia_Kazan" title="Elia Kazan">Elia Kazan</a></span></td>
+<td>Horizon-American Pictures</td>
+<td>8</td>
+<td>19
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Schindler%27s_List" title="Schindler&#39;s List">Schindler's List</a></i></td>
+<td>1993</td>
+<td><span data-sort-value="Spielberg&#160;!"><a href="/wiki/Steven_Spielberg" title="Steven Spielberg">Steven Spielberg</a></span></td>
+<td><a href="/wiki/Amblin_Entertainment" title="Amblin Entertainment">Amblin Entertainment</a></td>
+<td>9</td>
+<td>8
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Singin%27_in_the_Rain" title="Singin&#39; in the Rain">Singin' in the Rain</a></i></td>
+<td>1952</td>
+<td><span data-sort-value="Kelly&#160;!"><a href="/wiki/Gene_Kelly" title="Gene Kelly">Gene Kelly</a></span>, <a href="/wiki/Stanley_Donen" title="Stanley Donen">Stanley Donen</a></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>10</td>
+<td>5
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/It%27s_a_Wonderful_Life" title="It&#39;s a Wonderful Life">It's a Wonderful Life</a></i></td>
+<td>1946</td>
+<td><span data-sort-value="Capra&#160;!"><a href="/wiki/Frank_Capra" title="Frank Capra">Frank Capra</a></span></td>
+<td><a href="/wiki/Liberty_Pictures" title="Liberty Pictures">Liberty Pictures</a></td>
+<td>11</td>
+<td>20
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Sunset_Boulevard_(film)" title="Sunset Boulevard (film)">Sunset Boulevard</a></i></td>
+<td>1950</td>
+<td><span data-sort-value="Wilder&#160;!"><a href="/wiki/Billy_Wilder" title="Billy Wilder">Billy Wilder</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td>12</td>
+<td>16
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Bridge on the River Kwai&#160;!"><i><a href="/wiki/The_Bridge_on_the_River_Kwai" title="The Bridge on the River Kwai">The Bridge on the River Kwai</a></i></span></td>
+<td>1957</td>
+<td><span data-sort-value="Lean&#160;!"><a href="/wiki/David_Lean" title="David Lean">David Lean</a></span></td>
+<td>Horizon-American Pictures</td>
+<td>13</td>
+<td>36
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Some_Like_It_Hot" title="Some Like It Hot">Some Like It Hot</a></i></td>
+<td>1959</td>
+<td><span data-sort-value="Wilder&#160;!"><a href="/wiki/Billy_Wilder" title="Billy Wilder">Billy Wilder</a></span></td>
+<td>Ashton Productions, <a href="/wiki/The_Mirisch_Company" title="The Mirisch Company">The Mirisch Company</a></td>
+<td>14</td>
+<td>22
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Star_Wars_(film)" title="Star Wars (film)">Star Wars</a></i></td>
+<td>1977</td>
+<td><span data-sort-value="Lucas&#160;!"><a href="/wiki/George_Lucas" title="George Lucas">George Lucas</a></span></td>
+<td><a href="/wiki/Lucasfilm" title="Lucasfilm">Lucasfilm</a></td>
+<td>15</td>
+<td>13
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/All_About_Eve" title="All About Eve">All About Eve</a></i></td>
+<td>1950</td>
+<td><span data-sort-value="Mankiewicz&#160;!"><a href="/wiki/Joseph_L._Mankiewicz" title="Joseph L. Mankiewicz">Joseph L. Mankiewicz</a></span></td>
+<td><a href="/wiki/20th_Century-Fox" class="mw-redirect" title="20th Century-Fox">20th Century-Fox</a></td>
+<td>16</td>
+<td>28
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="African Queen&#160;!"><i><a href="/wiki/The_African_Queen_(film)" title="The African Queen (film)">The African Queen</a></i></span></td>
+<td>1951</td>
+<td><span data-sort-value="Huston&#160;!"><a href="/wiki/John_Huston" title="John Huston">John Huston</a></span></td>
+<td>Horizon Enterprises, <a href="/wiki/Romulus_Films" class="mw-redirect" title="Romulus Films">Romulus Films</a></td>
+<td>17</td>
+<td>65
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Psycho_(1960_film)" title="Psycho (1960 film)">Psycho</a></i></td>
+<td>1960</td>
+<td><span data-sort-value="Hitchcock&#160;!"><a href="/wiki/Alfred_Hitchcock" title="Alfred Hitchcock">Alfred Hitchcock</a></span></td>
+<td>Shamley Productions</td>
+<td>18</td>
+<td>14
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Chinatown_(1974_film)" title="Chinatown (1974 film)">Chinatown</a></i></td>
+<td>1974</td>
+<td><span data-sort-value="Polanski&#160;!"><a href="/wiki/Roman_Polanski" title="Roman Polanski">Roman Polanski</a></span></td>
+<td>Long Road Productions</td>
+<td>19</td>
+<td>21
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/One_Flew_Over_the_Cuckoo%27s_Nest_(film)" title="One Flew Over the Cuckoo&#39;s Nest (film)">One Flew Over the Cuckoo's Nest</a></i></td>
+<td>1975</td>
+<td><span data-sort-value="Forman&#160;!"><a href="/wiki/Milo%C5%A1_Forman" title="Miloš Forman">Miloš Forman</a></span></td>
+<td>Fantasy Films</td>
+<td>20</td>
+<td>33
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Grapes of Wrath&#160;!"><i><a href="/wiki/The_Grapes_of_Wrath_(film)" title="The Grapes of Wrath (film)">The Grapes of Wrath</a></i></span></td>
+<td>1940</td>
+<td><span data-sort-value="Ford&#160;!"><a href="/wiki/John_Ford" title="John Ford">John Ford</a></span></td>
+<td><a href="/wiki/20th_Century-Fox" class="mw-redirect" title="20th Century-Fox">20th Century-Fox</a></td>
+<td>21</td>
+<td>23
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/2001:_A_Space_Odyssey" title="2001: A Space Odyssey">2001: A Space Odyssey</a></i></td>
+<td>1968</td>
+<td><span data-sort-value="Kubrick&#160;!"><a href="/wiki/Stanley_Kubrick" title="Stanley Kubrick">Stanley Kubrick</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>22</td>
+<td>15
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Maltese Falcon&#160;!"><i><a href="/wiki/The_Maltese_Falcon_(1941_film)" title="The Maltese Falcon (1941 film)">The Maltese Falcon</a></i></span></td>
+<td>1941</td>
+<td><span data-sort-value="Huston&#160;!"><a href="/wiki/John_Huston" title="John Huston">John Huston</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>23</td>
+<td>31
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Raging_Bull" title="Raging Bull">Raging Bull</a></i></td>
+<td>1980</td>
+<td><span data-sort-value="Scorsese&#160;!"><a href="/wiki/Martin_Scorsese" title="Martin Scorsese">Martin Scorsese</a></span></td>
+<td>Chartoff-Winkler Productions</td>
+<td>24</td>
+<td>4
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/E.T._the_Extra-Terrestrial" title="E.T. the Extra-Terrestrial">E.T. the Extra-Terrestrial</a></i></td>
+<td>1982</td>
+<td><span data-sort-value="Spielberg&#160;!"><a href="/wiki/Steven_Spielberg" title="Steven Spielberg">Steven Spielberg</a></span></td>
+<td><a href="/wiki/Universal_Studios" class="mw-redirect" title="Universal Studios">Universal Pictures</a>, <a href="/wiki/Amblin_Entertainment" title="Amblin Entertainment">Amblin Entertainment</a></td>
+<td>25</td>
+<td>24
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Dr._Strangelove" title="Dr. Strangelove">Dr. Strangelove</a></i></td>
+<td>1964</td>
+<td><span data-sort-value="Kubrick&#160;!"><a href="/wiki/Stanley_Kubrick" title="Stanley Kubrick">Stanley Kubrick</a></span></td>
+<td><a href="/wiki/Hawk_Films" title="Hawk Films">Hawk Films</a>, Polaris Productions</td>
+<td>26</td>
+<td>39
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Bonnie_and_Clyde_(film)" title="Bonnie and Clyde (film)">Bonnie and Clyde</a></i></td>
+<td>1967</td>
+<td><span data-sort-value="Penn&#160;!"><a href="/wiki/Arthur_Penn" title="Arthur Penn">Arthur Penn</a></span></td>
+<td>Tatira-Hiller Productions</td>
+<td>27</td>
+<td>42
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Apocalypse_Now" title="Apocalypse Now">Apocalypse Now</a></i></td>
+<td>1979</td>
+<td><span data-sort-value="Coppola&#160;!"><a href="/wiki/Francis_Ford_Coppola" title="Francis Ford Coppola">Francis Ford Coppola</a></span></td>
+<td><a href="/wiki/American_Zoetrope" title="American Zoetrope">Omni Zoetrope</a></td>
+<td>28</td>
+<td>30
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Mr._Smith_Goes_to_Washington" title="Mr. Smith Goes to Washington">Mr. Smith Goes to Washington</a></i></td>
+<td>1939</td>
+<td><span data-sort-value="Capra&#160;!"><a href="/wiki/Frank_Capra" title="Frank Capra">Frank Capra</a></span></td>
+<td><a href="/wiki/Columbia_Pictures" title="Columbia Pictures">Columbia Pictures</a></td>
+<td>29</td>
+<td>26
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Treasure of the Sierra Madre&#160;!"><i><a href="/wiki/The_Treasure_of_the_Sierra_Madre_(film)" title="The Treasure of the Sierra Madre (film)">The Treasure of the Sierra Madre</a></i></span></td>
+<td>1948</td>
+<td><span data-sort-value="Huston&#160;!"><a href="/wiki/John_Huston" title="John Huston">John Huston</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>30</td>
+<td>38
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Annie_Hall" title="Annie Hall">Annie Hall</a></i></td>
+<td>1977</td>
+<td><span data-sort-value="Allen&#160;!"><a href="/wiki/Woody_Allen" title="Woody Allen">Woody Allen</a></span></td>
+<td><a href="/wiki/United_Artists" title="United Artists">United Artists</a></td>
+<td>31</td>
+<td>35
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Godfather Part II&#160;!"><i><a href="/wiki/The_Godfather_Part_II" title="The Godfather Part II">The Godfather Part II</a></i></span></td>
+<td>1974</td>
+<td><span data-sort-value="Coppola&#160;!"><a href="/wiki/Francis_Ford_Coppola" title="Francis Ford Coppola">Francis Ford Coppola</a></span></td>
+<td>The Coppola Company</td>
+<td>32</td>
+<td>32
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/High_Noon" title="High Noon">High Noon</a></i></td>
+<td>1952</td>
+<td><span data-sort-value="Zinnemann&#160;!"><a href="/wiki/Fred_Zinnemann" title="Fred Zinnemann">Fred Zinnemann</a></span></td>
+<td>Stanley Kramer Productions</td>
+<td>33</td>
+<td>27
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/To_Kill_a_Mockingbird_(film)" title="To Kill a Mockingbird (film)">To Kill a Mockingbird</a></i></td>
+<td>1962</td>
+<td><span data-sort-value="Mulligan&#160;!"><a href="/wiki/Robert_Mulligan" title="Robert Mulligan">Robert Mulligan</a></span></td>
+<td>Pakula-Mulligan Productions, <a href="/wiki/Brentwood_Productions" class="mw-redirect" title="Brentwood Productions">Brentwood Productions</a></td>
+<td>34</td>
+<td>25
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/It_Happened_One_Night" title="It Happened One Night">It Happened One Night</a></i></td>
+<td>1934</td>
+<td><span data-sort-value="Capra&#160;!"><a href="/wiki/Frank_Capra" title="Frank Capra">Frank Capra</a></span></td>
+<td><a href="/wiki/Columbia_Pictures" title="Columbia Pictures">Columbia Pictures</a></td>
+<td>35</td>
+<td>46
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Midnight_Cowboy" title="Midnight Cowboy">Midnight Cowboy</a></i></td>
+<td>1969</td>
+<td><span data-sort-value="Schlesinger&#160;!"><a href="/wiki/John_Schlesinger" title="John Schlesinger">John Schlesinger</a></span></td>
+<td><a href="/wiki/Jerome_Hellman" title="Jerome Hellman">Jerome Hellman</a> Productions</td>
+<td>36</td>
+<td>43
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Best Years of Our Lives&#160;!"><i><a href="/wiki/The_Best_Years_of_Our_Lives" title="The Best Years of Our Lives">The Best Years of Our Lives</a></i></span></td>
+<td>1946</td>
+<td><span data-sort-value="Wyler&#160;!"><a href="/wiki/William_Wyler" title="William Wyler">William Wyler</a></span></td>
+<td><a href="/wiki/Samuel_Goldwyn_Productions" title="Samuel Goldwyn Productions">Samuel Goldwyn Productions</a></td>
+<td>37</td>
+<td>37
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Double_Indemnity" title="Double Indemnity">Double Indemnity</a></i></td>
+<td>1944</td>
+<td><span data-sort-value="Wilder&#160;!"><a href="/wiki/Billy_Wilder" title="Billy Wilder">Billy Wilder</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td>38</td>
+<td>29
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Doctor_Zhivago_(film)" title="Doctor Zhivago (film)">Doctor Zhivago</a></i></td>
+<td>1965</td>
+<td><span data-sort-value="Lean&#160;!"><a href="/wiki/David_Lean" title="David Lean">David Lean</a></span></td>
+<td><a href="/wiki/Carlo_Ponti" title="Carlo Ponti">Carlo Ponti</a> Productions</td>
+<td>39</td>
+<td><span data-sort-value="101&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/North_by_Northwest" title="North by Northwest">North by Northwest</a></i></td>
+<td>1959</td>
+<td><span data-sort-value="Hitchcock&#160;!"><a href="/wiki/Alfred_Hitchcock" title="Alfred Hitchcock">Alfred Hitchcock</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>40</td>
+<td>55
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/West_Side_Story_(1961_film)" title="West Side Story (1961 film)">West Side Story</a></i></td>
+<td>1961</td>
+<td><span data-sort-value="Wise&#160;!"><a href="/wiki/Robert_Wise" title="Robert Wise">Robert Wise</a></span>, <a href="/wiki/Jerome_Robbins" title="Jerome Robbins">Jerome Robbins</a></td>
+<td>Beta Productions, <a href="/wiki/The_Mirisch_Company" title="The Mirisch Company">The Mirisch Company</a>, <a href="/wiki/Seven_Arts_Productions" title="Seven Arts Productions">Seven Arts Productions</a>, B &amp; P Enterprises</td>
+<td>41</td>
+<td>51
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Rear_Window" title="Rear Window">Rear Window</a></i></td>
+<td>1954</td>
+<td><span data-sort-value="Hitchcock&#160;!"><a href="/wiki/Alfred_Hitchcock" title="Alfred Hitchcock">Alfred Hitchcock</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a>, Patron</td>
+<td>42</td>
+<td>48
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/King_Kong_(1933_film)" title="King Kong (1933 film)">King Kong</a></i></td>
+<td>1933</td>
+<td><span data-sort-value="Cooper&#160;!"><a href="/wiki/Merian_C._Cooper" title="Merian C. Cooper">Merian C. Cooper</a></span></td>
+<td><a href="/wiki/RKO_Radio_Pictures" class="mw-redirect" title="RKO Radio Pictures">RKO Radio Pictures</a></td>
+<td>43</td>
+<td>41
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Birth of a Nation&#160;!"><i><a href="/wiki/The_Birth_of_a_Nation" title="The Birth of a Nation">The Birth of a Nation</a></i></span></td>
+<td>1915</td>
+<td><span data-sort-value="Griffith&#160;!"><a href="/wiki/D._W._Griffith" title="D. W. Griffith">D. W. Griffith</a></span></td>
+<td>David W. Griffith Corp.</td>
+<td>44</td>
+<td><span data-sort-value="102&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Streetcar Named Desire&#160;!"><i><a href="/wiki/A_Streetcar_Named_Desire_(1951_film)" title="A Streetcar Named Desire (1951 film)">A Streetcar Named Desire</a></i></span></td>
+<td>1951</td>
+<td><span data-sort-value="Kazan&#160;!"><a href="/wiki/Elia_Kazan" title="Elia Kazan">Elia Kazan</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a>, <a href="/wiki/Charles_K._Feldman_Productions" class="mw-redirect" title="Charles K. Feldman Productions">Charles K. Feldman Productions</a></td>
+<td>45</td>
+<td>47
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Clockwork Orange&#160;!"><i><a href="/wiki/A_Clockwork_Orange_(film)" title="A Clockwork Orange (film)">A Clockwork Orange</a></i></span></td>
+<td>1971</td>
+<td><span data-sort-value="Kubrick&#160;!"><a href="/wiki/Stanley_Kubrick" title="Stanley Kubrick">Stanley Kubrick</a></span></td>
+<td>Polaris Productions, <a href="/wiki/Hawk_Films" title="Hawk Films">Hawk Films</a></td>
+<td>46</td>
+<td>70
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Taxi_Driver" title="Taxi Driver">Taxi Driver</a></i></td>
+<td>1976</td>
+<td><span data-sort-value="Scorsese&#160;!"><a href="/wiki/Martin_Scorsese" title="Martin Scorsese">Martin Scorsese</a></span></td>
+<td>B &amp; P Enterprises, Italo-Judeo</td>
+<td>47</td>
+<td>52
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Jaws_(film)" title="Jaws (film)">Jaws</a></i></td>
+<td>1975</td>
+<td><span data-sort-value="Spielberg&#160;!"><a href="/wiki/Steven_Spielberg" title="Steven Spielberg">Steven Spielberg</a></span></td>
+<td><a href="/wiki/Universal_Studios" class="mw-redirect" title="Universal Studios">Universal Pictures</a>, <a href="/wiki/Zanuck/Brown_Company" class="mw-redirect" title="Zanuck/Brown Company">Zanuck/Brown Company</a></td>
+<td>48</td>
+<td>56
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Snow_White_and_the_Seven_Dwarfs_(1937_film)" title="Snow White and the Seven Dwarfs (1937 film)">Snow White and the Seven Dwarfs</a></i></td>
+<td>1937</td>
+<td><span data-sort-value="Hand&#160;!"><a href="/wiki/David_Hand_(animator)" title="David Hand (animator)">David Hand</a>, et al.</span></td>
+<td><a href="/wiki/Walt_Disney_Pictures" title="Walt Disney Pictures">Walt Disney Productions</a></td>
+<td>49</td>
+<td>34
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Butch_Cassidy_and_the_Sundance_Kid" title="Butch Cassidy and the Sundance Kid">Butch Cassidy and the Sundance Kid</a></i></td>
+<td>1969</td>
+<td><span data-sort-value="Hill&#160;!"><a href="/wiki/George_Roy_Hill" title="George Roy Hill">George Roy Hill</a></span></td>
+<td>Campanile Productions</td>
+<td>50</td>
+<td>73
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Philadelphia Story&#160;!"><i><a href="/wiki/The_Philadelphia_Story_(film)" title="The Philadelphia Story (film)">The Philadelphia Story</a></i></span></td>
+<td>1940</td>
+<td><span data-sort-value="Cukor&#160;!"><a href="/wiki/George_Cukor" title="George Cukor">George Cukor</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>51</td>
+<td>44
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/From_Here_to_Eternity" title="From Here to Eternity">From Here to Eternity</a></i></td>
+<td>1953</td>
+<td><span data-sort-value="Zinnemann&#160;!"><a href="/wiki/Fred_Zinnemann" title="Fred Zinnemann">Fred Zinnemann</a></span></td>
+<td><a href="/wiki/Columbia_Pictures" title="Columbia Pictures">Columbia Pictures</a></td>
+<td>52</td>
+<td><span data-sort-value="103&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Amadeus_(film)" title="Amadeus (film)">Amadeus</a></i></td>
+<td>1984</td>
+<td><span data-sort-value="Forman&#160;!"><a href="/wiki/Milo%C5%A1_Forman" title="Miloš Forman">Miloš Forman</a></span></td>
+<td><a href="/wiki/The_Saul_Zaentz_Company" class="mw-redirect" title="The Saul Zaentz Company">The Saul Zaentz Company</a></td>
+<td>53</td>
+<td><span data-sort-value="104&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/All_Quiet_on_the_Western_Front_(1930_film)" title="All Quiet on the Western Front (1930 film)">All Quiet on the Western Front</a></i></td>
+<td>1930</td>
+<td><span data-sort-value="Milestone&#160;!"><a href="/wiki/Lewis_Milestone" title="Lewis Milestone">Lewis Milestone</a></span></td>
+<td><a href="/wiki/Universal_Pictures" title="Universal Pictures">Universal Pictures</a></td>
+<td>54</td>
+<td><span data-sort-value="105&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Sound of Music&#160;!"><i><a href="/wiki/The_Sound_of_Music_(film)" title="The Sound of Music (film)">The Sound of Music</a></i></span></td>
+<td>1965</td>
+<td><span data-sort-value="Wise&#160;!"><a href="/wiki/Robert_Wise" title="Robert Wise">Robert Wise</a></span></td>
+<td>Argyle Enterprises, <a href="/wiki/20th_Century-Fox" class="mw-redirect" title="20th Century-Fox">20th Century-Fox</a></td>
+<td>55</td>
+<td>40
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/M*A*S*H_(film)" title="M*A*S*H (film)">M*A*S*H</a></i></td>
+<td>1970</td>
+<td><span data-sort-value="Altman&#160;!"><a href="/wiki/Robert_Altman" title="Robert Altman">Robert Altman</a></span></td>
+<td>Aspen Productions</td>
+<td>56</td>
+<td>54
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Third Man&#160;!"><i><a href="/wiki/The_Third_Man" title="The Third Man">The Third Man</a></i></span></td>
+<td>1949</td>
+<td><span data-sort-value="Reed&#160;!"><a href="/wiki/Carol_Reed" title="Carol Reed">Carol Reed</a></span></td>
+<td><a href="/wiki/London_Film_Productions" class="mw-redirect" title="London Film Productions">London Film Productions</a></td>
+<td>57</td>
+<td><span data-sort-value="106&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Fantasia_(1940_film)" title="Fantasia (1940 film)">Fantasia</a></i></td>
+<td>1940</td>
+<td><span data-sort-value="Disney&#160;!"><a href="/wiki/Walt_Disney" title="Walt Disney">Walt Disney</a></span></td>
+<td><a href="/wiki/Walt_Disney_Pictures" title="Walt Disney Pictures">Walt Disney Productions</a></td>
+<td>58</td>
+<td><span data-sort-value="107&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Rebel_Without_a_Cause" title="Rebel Without a Cause">Rebel Without a Cause</a></i></td>
+<td>1955</td>
+<td><span data-sort-value="Ray&#160;!"><a href="/wiki/Nicholas_Ray" title="Nicholas Ray">Nicholas Ray</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>59</td>
+<td><span data-sort-value="108&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Raiders_of_the_Lost_Ark" title="Raiders of the Lost Ark">Raiders of the Lost Ark</a></i></td>
+<td>1981</td>
+<td><span data-sort-value="Spielberg&#160;!"><a href="/wiki/Steven_Spielberg" title="Steven Spielberg">Steven Spielberg</a></span></td>
+<td><a href="/wiki/Lucasfilm" title="Lucasfilm">Lucasfilm</a></td>
+<td>60</td>
+<td>66
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Vertigo_(film)" title="Vertigo (film)">Vertigo</a></i></td>
+<td>1958</td>
+<td><span data-sort-value="Hitchcock&#160;!"><a href="/wiki/Alfred_Hitchcock" title="Alfred Hitchcock">Alfred Hitchcock</a></span></td>
+<td>Alfred J. Hitchcock Productions, <a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td>61</td>
+<td>9
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Tootsie" title="Tootsie">Tootsie</a></i></td>
+<td>1982</td>
+<td><span data-sort-value="Pollack&#160;!"><a href="/wiki/Sydney_Pollack" title="Sydney Pollack">Sydney Pollack</a></span></td>
+<td><a href="/wiki/Mirage_Enterprises" title="Mirage Enterprises">Mirage Enterprises</a>, Punch Productions, <a href="/wiki/Columbia_Pictures" title="Columbia Pictures">Columbia Pictures</a>, Delphi Productions</td>
+<td>62</td>
+<td>69
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Stagecoach_(1939_film)" title="Stagecoach (1939 film)">Stagecoach</a></i></td>
+<td>1939</td>
+<td><span data-sort-value="Ford&#160;!"><a href="/wiki/John_Ford" title="John Ford">John Ford</a></span></td>
+<td><a href="/wiki/Walter_Wanger_Productions" class="mw-redirect" title="Walter Wanger Productions">Walter Wanger Productions</a></td>
+<td>63</td>
+<td><span data-sort-value="109&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Close_Encounters_of_the_Third_Kind" title="Close Encounters of the Third Kind">Close Encounters of the Third Kind</a></i></td>
+<td>1977</td>
+<td><span data-sort-value="Spielberg&#160;!"><a href="/wiki/Steven_Spielberg" title="Steven Spielberg">Steven Spielberg</a></span></td>
+<td><a href="/wiki/Columbia_Pictures" title="Columbia Pictures">Columbia Pictures</a>, <a href="/wiki/EMI_Films" class="mw-redirect" title="EMI Films">EMI</a></td>
+<td>64</td>
+<td><span data-sort-value="110&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Silence&#160;!"><i><a href="/wiki/The_Silence_of_the_Lambs_(film)" title="The Silence of the Lambs (film)">The Silence of the Lambs</a></i></span></td>
+<td>1991</td>
+<td><span data-sort-value="Demme&#160;!"><a href="/wiki/Jonathan_Demme" title="Jonathan Demme">Jonathan Demme</a></span></td>
+<td>Strong Heart Productions</td>
+<td>65</td>
+<td>74
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Network_(1976_film)" title="Network (1976 film)">Network</a></i></td>
+<td>1976</td>
+<td><span data-sort-value="Lumet&#160;!"><a href="/wiki/Sidney_Lumet" title="Sidney Lumet">Sidney Lumet</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a>, <a href="/wiki/United_Artists" title="United Artists">United Artists</a></td>
+<td>66</td>
+<td>64
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Manchurian Candidate&#160;!"><i><a href="/wiki/The_Manchurian_Candidate_(1962_film)" title="The Manchurian Candidate (1962 film)">The Manchurian Candidate</a></i></span></td>
+<td>1962</td>
+<td><span data-sort-value="Frankenheimer&#160;!"><a href="/wiki/John_Frankenheimer" title="John Frankenheimer">John Frankenheimer</a></span></td>
+<td>M. C. Productions</td>
+<td>67</td>
+<td><span data-sort-value="111&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/An_American_in_Paris_(film)" title="An American in Paris (film)">An American in Paris</a></i></td>
+<td>1951</td>
+<td><span data-sort-value="Minnelli&#160;!"><a href="/wiki/Vincente_Minnelli" title="Vincente Minnelli">Vincente Minnelli</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>68</td>
+<td><span data-sort-value="112&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Shane_(film)" title="Shane (film)">Shane</a></i></td>
+<td>1953</td>
+<td><span data-sort-value="Stevens&#160;!"><a href="/wiki/George_Stevens" title="George Stevens">George Stevens</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td>69</td>
+<td>45
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="French Connection&#160;!"><i><a href="/wiki/The_French_Connection_(film)" title="The French Connection (film)">The French Connection</a></i></span></td>
+<td>1971</td>
+<td><span data-sort-value="Friedkin&#160;!"><a href="/wiki/William_Friedkin" title="William Friedkin">William Friedkin</a></span></td>
+<td>D'Antoni Productions</td>
+<td>70</td>
+<td>93
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Forrest_Gump" title="Forrest Gump">Forrest Gump</a></i></td>
+<td>1994</td>
+<td><span data-sort-value="Zemeckis&#160;!"><a href="/wiki/Robert_Zemeckis" title="Robert Zemeckis">Robert Zemeckis</a></span></td>
+<td>The Tisch Company</td>
+<td>71</td>
+<td>76
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Ben-Hur_(1959_film)" title="Ben-Hur (1959 film)">Ben-Hur</a></i></td>
+<td>1959</td>
+<td><span data-sort-value="Wyler&#160;!"><a href="/wiki/William_Wyler" title="William Wyler">William Wyler</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>72</td>
+<td>100
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Wuthering_Heights_(1939_film)" title="Wuthering Heights (1939 film)">Wuthering Heights</a></i></td>
+<td>1939</td>
+<td><span data-sort-value="Wyler&#160;!"><a href="/wiki/William_Wyler" title="William Wyler">William Wyler</a></span></td>
+<td><a href="/wiki/Samuel_Goldwyn_Productions" title="Samuel Goldwyn Productions">Samuel Goldwyn Productions</a></td>
+<td>73</td>
+<td><span data-sort-value="113&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Gold Rush&#160;!"><i><a href="/wiki/The_Gold_Rush" title="The Gold Rush">The Gold Rush</a></i></span></td>
+<td>1925</td>
+<td><span data-sort-value="Chaplin&#160;!"><a href="/wiki/Charlie_Chaplin" title="Charlie Chaplin">Charlie Chaplin</a></span></td>
+<td>Charles Chaplin Productions</td>
+<td>74</td>
+<td>58
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Dances_with_Wolves" title="Dances with Wolves">Dances with Wolves</a></i></td>
+<td>1990</td>
+<td><span data-sort-value="Costner&#160;!"><a href="/wiki/Kevin_Costner" title="Kevin Costner">Kevin Costner</a></span></td>
+<td>TIG Productions, Majestic Films International</td>
+<td>75</td>
+<td><span data-sort-value="114&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/City_Lights" title="City Lights">City Lights</a></i></td>
+<td>1931</td>
+<td><span data-sort-value="Chaplin&#160;!"><a href="/wiki/Charlie_Chaplin" title="Charlie Chaplin">Charlie Chaplin</a></span></td>
+<td>Charles Chaplin Productions</td>
+<td>76</td>
+<td>11
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/American_Graffiti" title="American Graffiti">American Graffiti</a></i></td>
+<td>1973</td>
+<td><span data-sort-value="Lucas&#160;!"><a href="/wiki/George_Lucas" title="George Lucas">George Lucas</a></span></td>
+<td>Coppola Co., <a href="/wiki/Lucasfilm" title="Lucasfilm">Lucasfilm</a></td>
+<td>77</td>
+<td>62
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Rocky" title="Rocky">Rocky</a></i></td>
+<td>1976</td>
+<td><span data-sort-value="Avildsen&#160;!"><a href="/wiki/John_G._Avildsen" title="John G. Avildsen">John G. Avildsen</a></span></td>
+<td>Chartoff-Winkler Productions</td>
+<td>78</td>
+<td>57
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Deer Hunter&#160;!"><i><a href="/wiki/The_Deer_Hunter" title="The Deer Hunter">The Deer Hunter</a></i></span></td>
+<td>1978</td>
+<td><span data-sort-value="Cimino&#160;!"><a href="/wiki/Michael_Cimino" title="Michael Cimino">Michael Cimino</a></span></td>
+<td><a href="/wiki/EMI_Films" class="mw-redirect" title="EMI Films">EMI</a></td>
+<td>79</td>
+<td>53
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Wild Bunch&#160;!"><i><a href="/wiki/The_Wild_Bunch" title="The Wild Bunch">The Wild Bunch</a></i></span></td>
+<td>1969</td>
+<td><span data-sort-value="Peckinpah&#160;!"><a href="/wiki/Sam_Peckinpah" title="Sam Peckinpah">Sam Peckinpah</a></span></td>
+<td>Phil Feldman Productions, <a href="/wiki/Warner_Bros.-Seven_Arts" title="Warner Bros.-Seven Arts">Warner Bros.-Seven Arts</a></td>
+<td>80</td>
+<td>79
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Modern_Times_(film)" title="Modern Times (film)">Modern Times</a></i></td>
+<td>1936</td>
+<td><span data-sort-value="Chaplin&#160;!"><a href="/wiki/Charlie_Chaplin" title="Charlie Chaplin">Charlie Chaplin</a></span></td>
+<td>Charles Chaplin Film Corp.</td>
+<td>81</td>
+<td>78
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Giant_(1956_film)" title="Giant (1956 film)">Giant</a></i></td>
+<td>1956</td>
+<td><span data-sort-value="Stevens&#160;!"><a href="/wiki/George_Stevens" title="George Stevens">George Stevens</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>82</td>
+<td><span data-sort-value="115&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Platoon_(film)" title="Platoon (film)">Platoon</a></i></td>
+<td>1986</td>
+<td><span data-sort-value="Stone&#160;!"><a href="/wiki/Oliver_Stone" title="Oliver Stone">Oliver Stone</a></span></td>
+<td><a href="/wiki/Hemdale_Film_Corporation" title="Hemdale Film Corporation">Hemdale Film Corporation</a></td>
+<td>83</td>
+<td>86
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Fargo_(1996_film)" title="Fargo (1996 film)">Fargo</a></i></td>
+<td>1996</td>
+<td><span data-sort-value="Coen&#160;!"><a href="/wiki/Joel_Coen" class="mw-redirect" title="Joel Coen">Joel Coen</a></span></td>
+<td><a href="/wiki/Working_Title_Films" title="Working Title Films">Working Title Films</a></td>
+<td>84</td>
+<td><span data-sort-value="116&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Duck_Soup_(1933_film)" title="Duck Soup (1933 film)">Duck Soup</a></i></td>
+<td>1933</td>
+<td><span data-sort-value="McCarey&#160;!"><a href="/wiki/Leo_McCarey" title="Leo McCarey">Leo McCarey</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Productions</a></td>
+<td>85</td>
+<td>60
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Mutiny_on_the_Bounty_(1935_film)" title="Mutiny on the Bounty (1935 film)">Mutiny on the Bounty</a></i></td>
+<td>1935</td>
+<td><span data-sort-value="Lloyd&#160;!"><a href="/wiki/Frank_Lloyd" title="Frank Lloyd">Frank Lloyd</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td>86</td>
+<td><span data-sort-value="117&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Frankenstein_(1931_film)" title="Frankenstein (1931 film)">Frankenstein</a></i></td>
+<td>1931</td>
+<td><span data-sort-value="Whale&#160;!"><a href="/wiki/James_Whale" title="James Whale">James Whale</a></span></td>
+<td><a href="/wiki/Universal_Pictures" title="Universal Pictures">Universal Pictures</a></td>
+<td>87</td>
+<td><span data-sort-value="118&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Easy_Rider" title="Easy Rider">Easy Rider</a></i></td>
+<td>1969</td>
+<td><span data-sort-value="Hopper&#160;!"><a href="/wiki/Dennis_Hopper" title="Dennis Hopper">Dennis Hopper</a></span></td>
+<td>The Pando Company, <a href="/wiki/Raybert_Productions" title="Raybert Productions">Raybert Productions</a></td>
+<td>88</td>
+<td>84
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Patton_(film)" title="Patton (film)">Patton</a></i></td>
+<td>1970</td>
+<td><span data-sort-value="Schaffner&#160;!"><a href="/wiki/Franklin_J._Schaffner" title="Franklin J. Schaffner">Franklin J. Schaffner</a></span></td>
+<td><a href="/wiki/20th_Century-Fox" class="mw-redirect" title="20th Century-Fox">20th Century-Fox</a></td>
+<td>89</td>
+<td><span data-sort-value="119&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Jazz Singer&#160;!"><i><a href="/wiki/The_Jazz_Singer" title="The Jazz Singer">The Jazz Singer</a></i></span></td>
+<td>1927</td>
+<td><span data-sort-value="Crosland&#160;!"><a href="/wiki/Alan_Crosland" title="Alan Crosland">Alan Crosland</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a>, <a href="/wiki/Vitaphone" title="Vitaphone">The Vitaphone Corp.</a></td>
+<td>90</td>
+<td><span data-sort-value="120&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/My_Fair_Lady_(film)" title="My Fair Lady (film)">My Fair Lady</a></i></td>
+<td>1964</td>
+<td><span data-sort-value="Cukor&#160;!"><a href="/wiki/George_Cukor" title="George Cukor">George Cukor</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>91</td>
+<td><span data-sort-value="121&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Place in the Sun&#160;!"><i><a href="/wiki/A_Place_in_the_Sun_(1951_film)" title="A Place in the Sun (1951 film)">A Place in the Sun</a></i></span></td>
+<td>1951</td>
+<td><span data-sort-value="Stevens&#160;!"><a href="/wiki/George_Stevens" title="George Stevens">George Stevens</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td>92</td>
+<td><span data-sort-value="122&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Apartment&#160;!"><i><a href="/wiki/The_Apartment" title="The Apartment">The Apartment</a></i></span></td>
+<td>1960</td>
+<td><span data-sort-value="Wilder&#160;!"><a href="/wiki/Billy_Wilder" title="Billy Wilder">Billy Wilder</a></span></td>
+<td><a href="/wiki/The_Mirisch_Company" title="The Mirisch Company">The Mirisch Company</a></td>
+<td>93</td>
+<td>80
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Goodfellas" title="Goodfellas">Goodfellas</a></i></td>
+<td>1990</td>
+<td><span data-sort-value="Scorsese&#160;!"><a href="/wiki/Martin_Scorsese" title="Martin Scorsese">Martin Scorsese</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a>, <a href="/wiki/Irwin_Winkler" title="Irwin Winkler">Irwin Winkler</a> Productions</td>
+<td>94</td>
+<td>92
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Pulp_Fiction" title="Pulp Fiction">Pulp Fiction</a></i></td>
+<td>1994</td>
+<td><span data-sort-value="Tarantino&#160;!"><a href="/wiki/Quentin_Tarantino" title="Quentin Tarantino">Quentin Tarantino</a></span></td>
+<td><a href="/wiki/A_Band_Apart" title="A Band Apart">A Band Apart</a>, <a href="/wiki/Jersey_Films" class="mw-redirect" title="Jersey Films">Jersey Films</a></td>
+<td>95</td>
+<td>94
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Searchers&#160;!"><i><a href="/wiki/The_Searchers" title="The Searchers">The Searchers</a></i></span></td>
+<td>1956</td>
+<td><span data-sort-value="Ford&#160;!"><a href="/wiki/John_Ford" title="John Ford">John Ford</a></span></td>
+<td>C. V. Whitney Pictures</td>
+<td>96</td>
+<td>12
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Bringing_Up_Baby" title="Bringing Up Baby">Bringing Up Baby</a></i></td>
+<td>1938</td>
+<td><span data-sort-value="Hawks&#160;!"><a href="/wiki/Howard_Hawks" title="Howard Hawks">Howard Hawks</a></span></td>
+<td><a href="/wiki/RKO_Radio_Pictures" class="mw-redirect" title="RKO Radio Pictures">RKO Radio Pictures</a></td>
+<td>97</td>
+<td>88
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Unforgiven" title="Unforgiven">Unforgiven</a></i></td>
+<td>1992</td>
+<td><span data-sort-value="Eastwood&#160;!"><a href="/wiki/Clint_Eastwood" title="Clint Eastwood">Clint Eastwood</a></span></td>
+<td><a href="/wiki/Malpaso_Productions" title="Malpaso Productions">The Malpaso Company</a></td>
+<td>98</td>
+<td>68
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Guess_Who%27s_Coming_to_Dinner" title="Guess Who&#39;s Coming to Dinner">Guess Who's Coming to Dinner</a></i></td>
+<td>1967</td>
+<td><span data-sort-value="Kramer&#160;!"><a href="/wiki/Stanley_Kramer" title="Stanley Kramer">Stanley Kramer</a></span></td>
+<td><a href="/wiki/Columbia_Pictures" title="Columbia Pictures">Columbia Pictures</a></td>
+<td>99</td>
+<td><span data-sort-value="123&#160;!">-</span>
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Yankee_Doodle_Dandy" title="Yankee Doodle Dandy">Yankee Doodle Dandy</a></i></td>
+<td>1942</td>
+<td><span data-sort-value="Curtiz&#160;!"><a href="/wiki/Michael_Curtiz" title="Michael Curtiz">Michael Curtiz</a></span></td>
+<td><a href="/wiki/Warner_Bros._Pictures" title="Warner Bros. Pictures">Warner Bros. Pictures</a></td>
+<td>100</td>
+<td>98
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="General&#160;!"><i><a href="/wiki/The_General_(1926_film)" title="The General (1926 film)">The General</a></i></span></td>
+<td>1926</td>
+<td><span data-sort-value="Keaton&#160;!"><a href="/wiki/Buster_Keaton" title="Buster Keaton">Buster Keaton</a></span></td>
+<td>Buster Keaton Productions, Joseph M. Schenck Productions</td>
+<td><span data-sort-value="101&#160;!">-</span></td>
+<td>18
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Intolerance_(film)" title="Intolerance (film)">Intolerance</a></i></td>
+<td>1916</td>
+<td><span data-sort-value="Griffith&#160;!"><a href="/wiki/D._W._Griffith" title="D. W. Griffith">D. W. Griffith</a></span></td>
+<td><a href="/wiki/Reliance-Majestic_Studios" title="Reliance-Majestic Studios">Reliance-Majestic Studios</a></td>
+<td><span data-sort-value="102&#160;!">-</span></td>
+<td>49
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Fellowship of the Ring&#160;!"><i><a href="/wiki/The_Lord_of_the_Rings:_The_Fellowship_of_the_Ring" title="The Lord of the Rings: The Fellowship of the Ring">The Fellowship of the Ring</a></i></span></td>
+<td>2001</td>
+<td><span data-sort-value="Jackson&#160;!"><a href="/wiki/Peter_Jackson" title="Peter Jackson">Peter Jackson</a></span></td>
+<td><a href="/wiki/New_Line_Cinema" title="New Line Cinema">New Line Cinema</a>, <a href="/wiki/WingNut_Films" title="WingNut Films">WingNut Films</a></td>
+<td><span data-sort-value="103&#160;!">-</span></td>
+<td>50
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Nashville_(film)" title="Nashville (film)">Nashville</a></i></td>
+<td>1975</td>
+<td><span data-sort-value="Altman&#160;!"><a href="/wiki/Robert_Altman" title="Robert Altman">Robert Altman</a></span></td>
+<td><a href="/wiki/ABC_Motion_Pictures" class="mw-redirect" title="ABC Motion Pictures">ABC Motion Pictures</a></td>
+<td><span data-sort-value="104&#160;!">-</span></td>
+<td>59
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Sullivan%27s_Travels" title="Sullivan&#39;s Travels">Sullivan's Travels</a></i></td>
+<td>1941</td>
+<td><span data-sort-value="Sturges&#160;!"><a href="/wiki/Preston_Sturges" title="Preston Sturges">Preston Sturges</a></span></td>
+<td><a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td><span data-sort-value="105&#160;!">-</span></td>
+<td>61
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Cabaret_(1972_film)" title="Cabaret (1972 film)">Cabaret</a></i></td>
+<td>1972</td>
+<td><span data-sort-value="Fosse&#160;!"><a href="/wiki/Bob_Fosse" title="Bob Fosse">Bob Fosse</a></span></td>
+<td><a href="/wiki/ABC_Pictures" class="mw-redirect" title="ABC Pictures">ABC Pictures</a>, <a href="/wiki/Monogram_Pictures" title="Monogram Pictures">Allied Artists</a></td>
+<td><span data-sort-value="106&#160;!">-</span></td>
+<td>63
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Who%27s_Afraid_of_Virginia_Woolf%3F_(film)" title="Who&#39;s Afraid of Virginia Woolf? (film)">Who's Afraid of Virginia Woolf?</a></i></td>
+<td>1966</td>
+<td><span data-sort-value="Nichols&#160;!"><a href="/wiki/Mike_Nichols" title="Mike Nichols">Mike Nichols</a></span></td>
+<td><a href="/wiki/Warner_Bros." title="Warner Bros.">Warner Bros.</a></td>
+<td><span data-sort-value="107&#160;!">-</span></td>
+<td>67
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Saving_Private_Ryan" title="Saving Private Ryan">Saving Private Ryan</a></i></td>
+<td>1998</td>
+<td><span data-sort-value="Spielberg&#160;!"><a href="/wiki/Steven_Spielberg" title="Steven Spielberg">Steven Spielberg</a></span></td>
+<td><a href="/wiki/Amblin_Entertainment" title="Amblin Entertainment">Amblin Entertainment</a>, <a href="/wiki/DreamWorks_Pictures" title="DreamWorks Pictures">DreamWorks Pictures</a></td>
+<td><span data-sort-value="108&#160;!">-</span></td>
+<td>71
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Shawshank Redemption&#160;!"><i><a href="/wiki/The_Shawshank_Redemption" title="The Shawshank Redemption">The Shawshank Redemption</a></i></span></td>
+<td>1994</td>
+<td><span data-sort-value="Darabont&#160;!"><a href="/wiki/Frank_Darabont" title="Frank Darabont">Frank Darabont</a></span></td>
+<td><a href="/wiki/Castle_Rock_Entertainment" title="Castle Rock Entertainment">Castle Rock Entertainment</a></td>
+<td><span data-sort-value="109&#160;!">-</span></td>
+<td>72
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/In_the_Heat_of_the_Night_(film)" title="In the Heat of the Night (film)">In the Heat of the Night</a></i></td>
+<td>1967</td>
+<td><span data-sort-value="Jewison&#160;!"><a href="/wiki/Norman_Jewison" title="Norman Jewison">Norman Jewison</a></span></td>
+<td><a href="/wiki/The_Mirisch_Corporation" class="mw-redirect" title="The Mirisch Corporation">The Mirisch Corporation</a></td>
+<td><span data-sort-value="110&#160;!">-</span></td>
+<td>75
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/All_the_President%27s_Men_(film)" title="All the President&#39;s Men (film)">All the President's Men</a></i></td>
+<td>1976</td>
+<td><span data-sort-value="Pakula&#160;!"><a href="/wiki/Alan_J._Pakula" title="Alan J. Pakula">Alan J. Pakula</a></span></td>
+<td>Wildwood Enterprises</td>
+<td><span data-sort-value="111&#160;!">-</span></td>
+<td>77
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Spartacus_(film)" title="Spartacus (film)">Spartacus</a></i></td>
+<td>1960</td>
+<td><span data-sort-value="Kubrick&#160;!"><a href="/wiki/Stanley_Kubrick" title="Stanley Kubrick">Stanley Kubrick</a></span></td>
+<td><a href="/wiki/Bryna_Productions" title="Bryna Productions">Bryna Productions</a></td>
+<td><span data-sort-value="112&#160;!">-</span></td>
+<td>81
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Sunrise:_A_Song_of_Two_Humans" title="Sunrise: A Song of Two Humans">Sunrise</a></i></td>
+<td>1927</td>
+<td><span data-sort-value="Murnau&#160;!"><a href="/wiki/F.W._Murnau" class="mw-redirect" title="F.W. Murnau">F.W. Murnau</a></span></td>
+<td><a href="/wiki/Fox_Film_Corporation" class="mw-redirect" title="Fox Film Corporation">Fox Film Corporation</a></td>
+<td><span data-sort-value="113&#160;!">-</span></td>
+<td>82
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Titanic_(1997_film)" title="Titanic (1997 film)">Titanic</a></i></td>
+<td>1997</td>
+<td><span data-sort-value="Cameron&#160;!"><a href="/wiki/James_Cameron" title="James Cameron">James Cameron</a></span></td>
+<td><a href="/wiki/Lightstorm_Entertainment" title="Lightstorm Entertainment">Lightstorm Entertainment</a>, <a href="/wiki/Paramount_Pictures" title="Paramount Pictures">Paramount Pictures</a></td>
+<td><span data-sort-value="114&#160;!">-</span></td>
+<td>83
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Night at the Opera&#160;!"><i><a href="/wiki/A_Night_at_the_Opera_(film)" title="A Night at the Opera (film)">A Night at the Opera</a></i></span></td>
+<td>1935</td>
+<td><span data-sort-value="Wood&#160;!"><a href="/wiki/Sam_Wood" title="Sam Wood">Sam Wood</a></span></td>
+<td><a href="/wiki/Metro-Goldwyn-Mayer" title="Metro-Goldwyn-Mayer">Metro-Goldwyn-Mayer</a></td>
+<td><span data-sort-value="115&#160;!">-</span></td>
+<td>85
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Twelve Angry Men&#160;!"><i><a href="/wiki/12_Angry_Men_(1957_film)" title="12 Angry Men (1957 film)">12 Angry Men</a></i></span></td>
+<td>1957</td>
+<td><span data-sort-value="Lumet&#160;!"><a href="/wiki/Sidney_Lumet" title="Sidney Lumet">Sidney Lumet</a></span></td>
+<td>Orion-Nova Productions</td>
+<td><span data-sort-value="116&#160;!">-</span></td>
+<td>87
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Sixth Sense&#160;!"><i><a href="/wiki/The_Sixth_Sense" title="The Sixth Sense">The Sixth Sense</a></i></span></td>
+<td>1999</td>
+<td><span data-sort-value="Shyamalan&#160;!"><a href="/wiki/M._Night_Shyamalan" title="M. Night Shyamalan">M. Night Shyamalan</a></span></td>
+<td><a href="/wiki/Hollywood_Pictures" title="Hollywood Pictures">Hollywood Pictures</a></td>
+<td><span data-sort-value="117&#160;!">-</span></td>
+<td>89
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Swing_Time_(film)" title="Swing Time (film)">Swing Time</a></i></td>
+<td>1936</td>
+<td><span data-sort-value="Stevens&#160;!"><a href="/wiki/George_Stevens" title="George Stevens">George Stevens</a></span></td>
+<td><a href="/wiki/RKO_Radio_Pictures" class="mw-redirect" title="RKO Radio Pictures">RKO Radio Pictures</a></td>
+<td><span data-sort-value="118&#160;!">-</span></td>
+<td>90
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Sophie%27s_Choice_(film)" title="Sophie&#39;s Choice (film)">Sophie's Choice</a></i></td>
+<td>1982</td>
+<td><span data-sort-value="Pakula&#160;!"><a href="/wiki/Alan_J._Pakula" title="Alan J. Pakula">Alan J. Pakula</a></span></td>
+<td><a href="/wiki/ITC_Entertainment" title="ITC Entertainment">ITC Entertainment</a></td>
+<td><span data-sort-value="119&#160;!">-</span></td>
+<td>91
+</td></tr>
+<tr>
+<td align="left"><span data-sort-value="Last Picture Show&#160;!"><i><a href="/wiki/The_Last_Picture_Show" title="The Last Picture Show">The Last Picture Show</a></i></span></td>
+<td>1971</td>
+<td><span data-sort-value="Bogdanovich&#160;!"><a href="/wiki/Peter_Bogdanovich" title="Peter Bogdanovich">Peter Bogdanovich</a></span></td>
+<td><a href="/wiki/BBS_Productions" class="mw-redirect" title="BBS Productions">BBS Productions</a></td>
+<td><span data-sort-value="120&#160;!">-</span></td>
+<td>95
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Do_the_Right_Thing" title="Do the Right Thing">Do the Right Thing</a></i></td>
+<td>1989</td>
+<td><span data-sort-value="Lee&#160;!"><a href="/wiki/Spike_Lee" title="Spike Lee">Spike Lee</a></span></td>
+<td><a href="/wiki/40_Acres_and_a_Mule_Filmworks" title="40 Acres and a Mule Filmworks">40 Acres and a Mule Filmworks</a></td>
+<td><span data-sort-value="121&#160;!">-</span></td>
+<td>96
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Blade_Runner" title="Blade Runner">Blade Runner</a></i></td>
+<td>1982</td>
+<td><span data-sort-value="Scott&#160;!"><a href="/wiki/Ridley_Scott" title="Ridley Scott">Ridley Scott</a></span></td>
+<td><a href="/wiki/The_Ladd_Company" title="The Ladd Company">The Ladd Company</a>, <a href="/wiki/Shaw_Brothers" class="mw-redirect" title="Shaw Brothers">Shaw Brothers</a></td>
+<td><span data-sort-value="122&#160;!">-</span></td>
+<td>97
+</td></tr>
+<tr>
+<td align="left"><i><a href="/wiki/Toy_Story" title="Toy Story">Toy Story</a></i></td>
+<td>1995</td>
+<td><span data-sort-value="Lasseter&#160;!"><a href="/wiki/John_Lasseter" title="John Lasseter">John Lasseter</a></span></td>
+<td><a href="/wiki/Walt_Disney_Pictures" title="Walt Disney Pictures">Walt Disney Pictures</a>, <a href="/wiki/Pixar_Animation_Studios" class="mw-redirect" title="Pixar Animation Studios">Pixar Animation Studios</a></td>
+<td><span data-sort-value="123&#160;!">-</span></td>
+<td>99
+</td></tr></tbody></table>
+<h3><span class="mw-headline" id="2007_changes">2007 changes</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=3" title="Edit section: 2007 changes"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>Twenty-three films were replaced in the 2007 tenth anniversary list. <i><a href="/wiki/Doctor_Zhivago_(film)" title="Doctor Zhivago (film)">Doctor Zhivago</a></i>, previously ranked #39, was the highest-ranked film to be dropped from the updated list, while <i><a href="/wiki/The_General_(1926_film)" title="The General (1926 film)">The General</a></i> at #18 was the highest-ranked new entry.
+</p>
+<h2><span class="mw-headline" id="Broadcast_history">Broadcast history</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=4" title="Edit section: Broadcast history"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Presentation_broadcast_on_CBS">Presentation broadcast on CBS</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=5" title="Edit section: Presentation broadcast on CBS"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>A 145-minute presentation of the 100 films aired on <a href="/wiki/CBS" title="CBS">CBS</a> on June 16, 1998.
+</p>
+<h3><span class="mw-headline" id="Presentation_broadcast_on_TNT">Presentation broadcast on TNT</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=6" title="Edit section: Presentation broadcast on TNT"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>A 460-minute version aired as a 10-part series on <a href="/wiki/TNT_(U.S._TV_network)" class="mw-redirect" title="TNT (U.S. TV network)">TNT</a>, narrated by <a href="/wiki/James_Woods" title="James Woods">James Woods</a> and hosted by American talents as follows:
+</p>
+<ul><li><a href="/wiki/Richard_Gere" title="Richard Gere">Richard Gere</a> hosted the episode "Against the Grain"</li>
+<li><a href="/wiki/Richard_Gere" title="Richard Gere">Richard Gere</a> hosted the episode "Beyond the Law"</li>
+<li><a href="/wiki/Sally_Field" title="Sally Field">Sally Field</a> hosted the episode "Family Portraits"</li>
+<li><a href="/wiki/Jodie_Foster" title="Jodie Foster">Jodie Foster</a> hosted the episode "In Search of..."</li>
+<li><a href="/wiki/Sally_Field" title="Sally Field">Sally Field</a> hosted the episode "Love Crazy"</li>
+<li><a href="/wiki/Richard_Gere" title="Richard Gere">Richard Gere</a> hosted the episode "War &amp; Peace"</li>
+<li><a href="/wiki/Sally_Field" title="Sally Field">Sally Field</a> hosted the episode "The Wilder Shores of Love"</li>
+<li><a href="/wiki/Jodie_Foster" title="Jodie Foster">Jodie Foster</a> hosted the episode "The Antiheroes"</li>
+<li><a href="/wiki/Richard_Gere" title="Richard Gere">Richard Gere</a> hosted the episode "Out of Control"</li>
+<li><a href="/wiki/Jodie_Foster" title="Jodie Foster">Jodie Foster</a> hosted the episode "Fantastic Flights"</li></ul>
+<h3><span class="mw-headline" id="Presentation_broadcast_on_TNT_UK">Presentation broadcast on TNT UK</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=7" title="Edit section: Presentation broadcast on TNT UK"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>Another version of the same 460-minute program was produced by Monique De Villiers and John Heyman from <i>A World Production</i> company to British television and market featuring different interviews and each segment being hosted by British talents in the following order:
+</p>
+<ul><li><a href="/wiki/Michael_Caine" title="Michael Caine">Michael Caine</a> hosted and narrated episode "Against the Grain"</li>
+<li><a href="/wiki/Ray_Winstone" title="Ray Winstone">Ray Winstone</a> hosted and narrated "Beyond the Law"</li>
+<li><a href="/wiki/Emily_Watson" title="Emily Watson">Emily Watson</a> hosted and narrated "Family Portraits"</li>
+<li><a href="/wiki/Richard_Harris" title="Richard Harris">Richard Harris</a> hosted and narrated "In Search of..."</li>
+<li><a href="/wiki/Joely_Richardson" title="Joely Richardson">Joely Richardson</a> hosted and narrated episode "Love Crazy"</li>
+<li><a href="/wiki/Jeremy_Irons" title="Jeremy Irons">Jeremy Irons</a> hosted and narrated episode "War and Peace"</li>
+<li><a href="/wiki/Liam_Neeson" title="Liam Neeson">Liam Neeson</a> hosted and narrated episode "The Wilder Shores of Love"</li>
+<li><a href="/wiki/Judi_Dench" title="Judi Dench">Judi Dench</a> hosted and narrated episode "The Anti-Heroes"</li>
+<li><a href="/wiki/Jude_Law" title="Jude Law">Jude Law</a> hosted and narrated episode "Out of Control"</li>
+<li><a href="/wiki/Helena_Bonham_Carter" title="Helena Bonham Carter">Helena Bonham Carter</a> hosted and narrated "Fantastic Flights"</li></ul>
+<h2><span class="mw-headline" id="Criticisms">Criticisms</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=8" title="Edit section: Criticisms"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<p>As with awards, the list of those who vote and the final vote tally are not released to the public, nor the criteria for how the 400 nominated films have been selected.
+</p><p>On June 26, 1998, the <i><a href="/wiki/Chicago_Reader" title="Chicago Reader">Chicago Reader</a></i> published an article by film critic <a href="/wiki/Jonathan_Rosenbaum" title="Jonathan Rosenbaum">Jonathan Rosenbaum</a> which offers a detailed response to the movies in the AFI list, as well as criticism of the AFI's appropriation of British films, such as <i><a href="/wiki/Lawrence_of_Arabia_(film)" title="Lawrence of Arabia (film)">Lawrence of Arabia</a></i> (albeit with aforementioned American funding) and <i><a href="/wiki/The_Third_Man" title="The Third Man">The Third Man</a></i>. Rosenbaum also produced an alternative list of 100 American movies that he felt had been overlooked by the AFI.<sup id="cite_ref-Rosenbaum_2-0" class="reference"><a href="#cite_note-Rosenbaum-2">&#91;2&#93;</a></sup> Rosenbaum chose to present this alternative list alphabetically since to rank them according to merit would be "tantamount to ranking oranges over apples or declaring cherries superior to grapes."
+</p><p>The <a href="/wiki/AFI%27s_100_Years...100_Movies_(10th_Anniversary_Edition)" title="AFI&#39;s 100 Years...100 Movies (10th Anniversary Edition)">AFI's 100 Years...100 Movies (10th Anniversary Edition)</a> list includes five titles from Rosenbaum's list (including <i><a href="/wiki/Do_the_Right_Thing" title="Do the Right Thing">Do the Right Thing</a></i>),<sup id="cite_ref-3" class="reference"><a href="#cite_note-3">&#91;3&#93;</a></sup> and the accompanying promotional poster lists the titles in alphabetical order.
+</p>
+<h2><span class="mw-headline" id="See_also">See also</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=9" title="Edit section: See also"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<ul><li><a href="/wiki/BFI_Top_100_British_films" title="BFI Top 100 British films">BFI Top 100 British films</a></li>
+<li><a href="/wiki/List_of_films_considered_the_best" title="List of films considered the best">List of films considered the best</a></li></ul>
+<h2><span class="mw-headline" id="References">References</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=10" title="Edit section: References"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<style data-mw-deduplicate="TemplateStyles:r1217336898">.mw-parser-output .reflist{font-size:90%;margin-bottom:0.5em;list-style-type:decimal}.mw-parser-output .reflist .references{font-size:100%;margin-bottom:0;list-style-type:inherit}.mw-parser-output .reflist-columns-2{column-width:30em}.mw-parser-output .reflist-columns-3{column-width:25em}.mw-parser-output .reflist-columns{margin-top:0.3em}.mw-parser-output .reflist-columns ol{margin-top:0}.mw-parser-output .reflist-columns li{page-break-inside:avoid;break-inside:avoid-column}.mw-parser-output .reflist-upper-alpha{list-style-type:upper-alpha}.mw-parser-output .reflist-upper-roman{list-style-type:upper-roman}.mw-parser-output .reflist-lower-alpha{list-style-type:lower-alpha}.mw-parser-output .reflist-lower-greek{list-style-type:lower-greek}.mw-parser-output .reflist-lower-roman{list-style-type:lower-roman}</style><div class="reflist">
+<div class="mw-references-wrap"><ol class="references">
+<li id="cite_note-1"><span class="mw-cite-backlink"><b><a href="#cite_ref-1">^</a></b></span> <span class="reference-text"><style data-mw-deduplicate="TemplateStyles:r1215172403">.mw-parser-output cite.citation{font-style:inherit;word-wrap:break-word}.mw-parser-output .citation q{quotes:"\"""\"""'""'"}.mw-parser-output .citation:target{background-color:rgba(0,127,255,0.133)}.mw-parser-output .id-lock-free.id-lock-free a{background:url("//upload.wikimedia.org/wikipedia/commons/6/65/Lock-green.svg")right 0.1em center/9px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-free a{background-size:contain}.mw-parser-output .id-lock-limited.id-lock-limited a,.mw-parser-output .id-lock-registration.id-lock-registration a{background:url("//upload.wikimedia.org/wikipedia/commons/d/d6/Lock-gray-alt-2.svg")right 0.1em center/9px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-limited a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-registration a{background-size:contain}.mw-parser-output .id-lock-subscription.id-lock-subscription a{background:url("//upload.wikimedia.org/wikipedia/commons/a/aa/Lock-red-alt-2.svg")right 0.1em center/9px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-subscription a{background-size:contain}.mw-parser-output .cs1-ws-icon a{background:url("//upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg")right 0.1em center/12px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .cs1-ws-icon a{background-size:contain}.mw-parser-output .cs1-code{color:inherit;background:inherit;border:none;padding:inherit}.mw-parser-output .cs1-hidden-error{display:none;color:#d33}.mw-parser-output .cs1-visible-error{color:#d33}.mw-parser-output .cs1-maint{display:none;color:#2C882D;margin-left:0.3em}.mw-parser-output .cs1-format{font-size:95%}.mw-parser-output .cs1-kern-left{padding-left:0.2em}.mw-parser-output .cs1-kern-right{padding-right:0.2em}.mw-parser-output .citation .mw-selflink{font-weight:inherit}html.skin-theme-clientpref-night .mw-parser-output .cs1-maint{color:#18911F}html.skin-theme-clientpref-night .mw-parser-output .cs1-visible-error,html.skin-theme-clientpref-night .mw-parser-output .cs1-hidden-error{color:#f8a397}@media(prefers-color-scheme:dark){html.skin-theme-clientpref-os .mw-parser-output .cs1-visible-error,html.skin-theme-clientpref-os .mw-parser-output .cs1-hidden-error{color:#f8a397}html.skin-theme-clientpref-os .mw-parser-output .cs1-maint{color:#18911F}}</style><cite class="citation web cs1"><a rel="nofollow" class="external text" href="https://www.filmsite.org/afi100films.html">"100 Greatest American Movies by AFI - Film Series"</a>. <i>www.filmsite.org</i>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=unknown&amp;rft.jtitle=www.filmsite.org&amp;rft.atitle=100+Greatest+American+Movies+by+AFI+-+Film+Series&amp;rft_id=https%3A%2F%2Fwww.filmsite.org%2Fafi100films.html&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AAFI%27s+100+Years...100+Movies" class="Z3988"></span></span>
+</li>
+<li id="cite_note-Rosenbaum-2"><span class="mw-cite-backlink"><b><a href="#cite_ref-Rosenbaum_2-0">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1215172403"><cite id="CITEREFRosenbaum1998" class="citation news cs1">Rosenbaum, Jonathan (June 26, 1998). <a rel="nofollow" class="external text" href="http://www.chicagoreader.com/movies/100best.html">"List-o-Mania: Or, How I Stopped Worrying and Learned to Love American Movies"</a>. Chicago Reader<span class="reference-accessdate">. Retrieved <span class="nowrap">2008-06-03</span></span>.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=article&amp;rft.atitle=List-o-Mania%3A+Or%2C+How+I+Stopped+Worrying+and+Learned+to+Love+American+Movies&amp;rft.date=1998-06-26&amp;rft.aulast=Rosenbaum&amp;rft.aufirst=Jonathan&amp;rft_id=http%3A%2F%2Fwww.chicagoreader.com%2Fmovies%2F100best.html&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AAFI%27s+100+Years...100+Movies" class="Z3988"></span></span>
+</li>
+<li id="cite_note-3"><span class="mw-cite-backlink"><b><a href="#cite_ref-3">^</a></b></span> <span class="reference-text"><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1215172403"><cite class="citation web cs1"><a rel="nofollow" class="external text" href="https://nofilmschool.com/what-are-afi-top-100-movies-all-time">"What Are the AFI Top 100 Movies of All Time?"</a>. <i>No Film School</i>. July 13, 2020.</cite><span title="ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=unknown&amp;rft.jtitle=No+Film+School&amp;rft.atitle=What+Are+the+AFI+Top+100+Movies+of+All+Time%3F&amp;rft.date=2020-07-13&amp;rft_id=https%3A%2F%2Fnofilmschool.com%2Fwhat-are-afi-top-100-movies-all-time&amp;rfr_id=info%3Asid%2Fen.wikipedia.org%3AAFI%27s+100+Years...100+Movies" class="Z3988"></span></span>
+</li>
+</ol></div></div>
+<h2><span class="mw-headline" id="External_links">External links</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;action=edit&amp;section=11" title="Edit section: External links"><span>edit</span></a><span class="mw-editsection-bracket">]</span></span></h2>
+<ul><li><a rel="nofollow" class="external text" href="https://www.afi.com/afis-100-years-100-movies/">AFI 100 Years...100 Movies</a> (1998 edition)</li>
+<li><a rel="nofollow" class="external text" href="https://www.afi.com/afis-100-years-100-movies-10th-anniversary-edition/">AFI 100 Years...100 Movies</a> (2007 edition)</li>
+<li><a rel="nofollow" class="external text" href="https://prdaficalmjediwestussa.blob.core.windows.net/images/2019/08/movies400.pdf">List of the 400 nominated movies</a> (1998 edition)</li>
+<li><a rel="nofollow" class="external text" href="https://prdaficalmjediwestussa.blob.core.windows.net/images/2019/08/Movies_ballot_06.pdf">List of the 400 nominated movies</a> (2007 edition)</li>
+<li><a rel="nofollow" class="external text" href="https://web.archive.org/web/20041215004842/http://www.montrealmirror.com/ARCHIVES/1998/082098/film1.html"><i>Montreal Mirror</i> editorial</a></li>
+<li><a rel="nofollow" class="external text" href="https://web.archive.org/web/20070929015608/http://www.sfment.com/dev/programs/view/17">SFM Entertainment page on the special; includes video clip</a></li></ul>
+<!-- 
+NewPP limit report
+Parsed by mw‐web.eqiad.main‐7d9f4666b8‐6sqhh
+Cached time: 20240614231052
+Cache expiry: 2592000
+Reduced expiry: false
+Complications: [vary‐revision‐sha1, show‐toc]
+CPU time usage: 0.409 seconds
+Real time usage: 0.535 seconds
+Preprocessor visited node count: 3139/1000000
+Post‐expand include size: 28739/2097152 bytes
+Template argument size: 5710/2097152 bytes
+Highest expansion depth: 8/100
+Expensive parser function count: 1/500
+Unstrip recursion depth: 1/20
+Unstrip post‐expand size: 16307/5000000 bytes
+Lua time usage: 0.214/10.000 seconds
+Lua memory usage: 3418819/52428800 bytes
+Number of Wikibase entities loaded: 0/400
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  398.265      1 -total
+ 27.41%  109.182      1 Template:Short_description
+ 26.66%  106.180      1 Template:Reflist
+ 23.57%   93.888    202 Template:Sort
+ 21.45%   85.438      2 Template:Cite_web
+ 19.13%   76.201      1 Template:AFI_100_Years..._series
+ 18.66%   74.312      1 Template:Infobox
+ 13.25%   52.770      2 Template:Pagetype
+ 10.91%   43.460      3 Template:Main_other
+ 10.44%   41.598      1 Template:SDcat
+-->
+
+<!-- Saved in parser cache with key enwiki:pcache:idhash:718307-0!canonical and timestamp 20240614231052 and revision id 1217354641. Rendering was triggered because: page-view
+ -->
+</div><!--esi <esi:include src="/esitest-fa8a495983347898/content" /> --><noscript><img src="https://login.wikimedia.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt="" width="1" height="1" style="border: none; position: absolute;"></noscript>
+<div class="printfooter" data-nosnippet="">Retrieved from "<a dir="ltr" href="https://en.wikipedia.org/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;oldid=1217354641">https://en.wikipedia.org/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;oldid=1217354641</a>"</div></div>
+					<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Help:Category" title="Help:Category">Category</a>: <ul><li><a href="/wiki/Category:AFI_100_Years..._series" title="Category:AFI 100 Years... series">AFI 100 Years... series</a></li></ul></div><div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Hidden categories: <ul><li><a href="/wiki/Category:Articles_with_short_description" title="Category:Articles with short description">Articles with short description</a></li><li><a href="/wiki/Category:Short_description_is_different_from_Wikidata" title="Category:Short description is different from Wikidata">Short description is different from Wikidata</a></li></ul></div></div>
+				</div>
+			</main>
+			
+		</div>
+		<div class="mw-footer-container">
+			
+<footer id="footer" class="mw-footer" >
+	<ul id="footer-info">
+	<li id="footer-info-lastmod"> This page was last edited on 5 April 2024, at 10:12<span class="anonymous-show">&#160;(UTC)</span>.</li>
+	<li id="footer-info-copyright">Text is available under the <a rel="license" href="//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License">Creative Commons Attribution-ShareAlike License 4.0</a><a rel="license" href="//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License" style="display:none;"></a>;
+additional terms may apply. By using this site, you agree to the <a href="//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Terms_of_Use">Terms of Use</a> and <a href="//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy">Privacy Policy</a>. Wikipedia® is a registered trademark of the <a href="//www.wikimediafoundation.org/">Wikimedia Foundation, Inc.</a>, a non-profit organization.</li>
+</ul>
+
+	<ul id="footer-places">
+	<li id="footer-places-privacy"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy">Privacy policy</a></li>
+	<li id="footer-places-about"><a href="/wiki/Wikipedia:About">About Wikipedia</a></li>
+	<li id="footer-places-disclaimers"><a href="/wiki/Wikipedia:General_disclaimer">Disclaimers</a></li>
+	<li id="footer-places-contact"><a href="//en.wikipedia.org/wiki/Wikipedia:Contact_us">Contact Wikipedia</a></li>
+	<li id="footer-places-wm-codeofconduct"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Universal_Code_of_Conduct">Code of Conduct</a></li>
+	<li id="footer-places-developers"><a href="https://developer.wikimedia.org">Developers</a></li>
+	<li id="footer-places-statslink"><a href="https://stats.wikimedia.org/#/en.wikipedia.org">Statistics</a></li>
+	<li id="footer-places-cookiestatement"><a href="https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement">Cookie statement</a></li>
+	<li id="footer-places-mobileview"><a href="//en.m.wikipedia.org/w/index.php?title=AFI%27s_100_Years...100_Movies&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+</ul>
+
+	<ul id="footer-icons" class="noprint">
+	<li id="footer-copyrightico"><a href="https://wikimediafoundation.org/"><img src="/static/images/footer/wikimedia-button.png" srcset="/static/images/footer/wikimedia-button-1.5x.png 1.5x, /static/images/footer/wikimedia-button-2x.png 2x" width="88" height="31" alt="Wikimedia Foundation" loading="lazy" /></a></li>
+	<li id="footer-poweredbyico"><a href="https://www.mediawiki.org/"><img src="/static/images/footer/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/static/images/footer/poweredby_mediawiki_132x47.png 1.5x, /static/images/footer/poweredby_mediawiki_176x62.png 2x" width="88" height="31" loading="lazy"></a></li>
+</ul>
+
+</footer>
+
+		</div>
+	</div> 
+</div> 
+<div class="vector-settings" id="p-dock-bottom">
+	<ul>
+		<li>
+		</li>
+	</ul>
+</div>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgHostname":"mw-web.eqiad.main-7d9f4666b8-445k4","wgBackendResponseTime":206,"wgPageParseReport":{"limitreport":{"cputime":"0.409","walltime":"0.535","ppvisitednodes":{"value":3139,"limit":1000000},"postexpandincludesize":{"value":28739,"limit":2097152},"templateargumentsize":{"value":5710,"limit":2097152},"expansiondepth":{"value":8,"limit":100},"expensivefunctioncount":{"value":1,"limit":500},"unstrip-depth":{"value":1,"limit":20},"unstrip-size":{"value":16307,"limit":5000000},"entityaccesscount":{"value":0,"limit":400},"timingprofile":["100.00%  398.265      1 -total"," 27.41%  109.182      1 Template:Short_description"," 26.66%  106.180      1 Template:Reflist"," 23.57%   93.888    202 Template:Sort"," 21.45%   85.438      2 Template:Cite_web"," 19.13%   76.201      1 Template:AFI_100_Years..._series"," 18.66%   74.312      1 Template:Infobox"," 13.25%   52.770      2 Template:Pagetype"," 10.91%   43.460      3 Template:Main_other"," 10.44%   41.598      1 Template:SDcat"]},"scribunto":{"limitreport-timeusage":{"value":"0.214","limit":"10.000"},"limitreport-memusage":{"value":3418819,"limit":52428800}},"cachereport":{"origin":"mw-web.eqiad.main-7d9f4666b8-6sqhh","timestamp":"20240614231052","ttl":2592000,"transientcontent":false}}});});</script>
+<script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"Article","name":"AFI's 100 Years...100 Movies","url":"https:\/\/en.wikipedia.org\/wiki\/AFI%27s_100_Years...100_Movies","sameAs":"http:\/\/www.wikidata.org\/entity\/Q719345","mainEntity":"http:\/\/www.wikidata.org\/entity\/Q719345","author":{"@type":"Organization","name":"Contributors to Wikimedia projects"},"publisher":{"@type":"Organization","name":"Wikimedia Foundation, Inc.","logo":{"@type":"ImageObject","url":"https:\/\/www.wikimedia.org\/static\/images\/wmf-hor-googpub.png"}},"datePublished":"2004-06-12T02:33:49Z","dateModified":"2024-04-05T10:12:02Z","headline":"Wikimedia list article"}</script>
+</body>
+</html>


### PR DESCRIPTION
Artigo web sobre os 100 melhores filmes listados pelo Instituto Americano de Cinema. Esse artigo está na Wikipedia e, na lateral direita da página, temos uma tabela contendo outros artigos criados pelo mesmo instituto, de 1998 a 2008. Há uma versão atualizada de 2007 do nosso artigo em questão, mas verificaremos a de 1988 primeiro.